### PR TITLE
fix: update installation step to include MyST parser for Sphinx docum…

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -26,10 +26,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install Sphinx
+      - name: Install Sphinx and MyST
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx sphinx_rtd_theme
+          # Install Sphinx, MyST (Markdown support), and RTD theme
+          pip install sphinx myst-parser sphinx_rtd_theme
           pip install -e .
 
       - name: Build Sphinx HTML

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datavizhub"
-version = "0.1.19"
+version = "0.1.20"
 description = "A tool to ingest data from various sources and formats, create imagery or video based on that data, and send the results to various locations for dissemination."
 authors = ["Eric Hackathorn <eric.j.hackathorn@noaa.gov>"]
 include = [


### PR DESCRIPTION
This pull request makes a small update to the documentation build workflow. The change ensures that the documentation generator supports Markdown files by installing the `myst-parser` package alongside Sphinx and the RTD theme.

* Updated the Sphinx installation step in `.github/workflows/docs-pages.yaml` to include `myst-parser`, enabling Markdown support in documentation builds.…entation