### PR TITLE
37 cli ai wizard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - Opt-in extras locally as needed, e.g.: `poetry install --with dev -E connectors -E processing -E visualization` or `--all-extras`.
 - Spawn shell: `poetry shell`.
 - Run a script or module: `poetry run python path/to/your_script.py` or `poetry run python -m your.module`.
-- Lint/format (if added): `poetry run black . && poetry run isort . && poetry run flake8`.
+- Lint/format: `poetry run ruff format . && poetry run ruff check .` (Ruff replaces Black/Isort/Flake8 when configured).
 - FFmpeg-required flows: ensure `ffmpeg` and `ffprobe` are installed on the system.
 
 ## Coding Style & Naming Conventions

--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ with open("/data/out/movie.mp4", "rb") as f:
   - Security Quickstart: https://github.com/NOAA-GSL/datavizhub/wiki/DataVizHub-API-Security-Quickstart
 - API docs (GitHub Pages): https://noaa-gsl.github.io/datavizhub/
 - CI-synced wiki: A GitHub Action mirrors the wiki into `docs/source/wiki/` so Sphinx can build it with the docs. Sync commits occur only on `main`; PRs/branches use the synced copy for builds without committing changes.
+ - Wizard REPL (experimental): see docs/wizard-cli.md for autocomplete and edit-before-run usage.
 
 ## Notes
 - Paths: examples use absolute paths (e.g., `/data/...`) for clarity, but the library does not assume a specific root; configure paths via your own settings or env vars if preferred.

--- a/docs/wizard-cli.md
+++ b/docs/wizard-cli.md
@@ -1,0 +1,21 @@
+# DataVizHub Wizard REPL
+
+The Wizard is an interactive assistant that suggests and runs `datavizhub` CLI commands.
+
+- Autocomplete: When `prompt_toolkit` is installed (via extra `wizard`), the REPL offers
+  completions for command names, common options, and file paths for `--input/--output`.
+- Edit-before-run: After suggestions, choose to run, edit, or cancel. Edited commands
+  are re‑sanitized to keep only `datavizhub ...` lines and strip inline `#` comments.
+
+Flags and env vars
+- `--edit`: always open the editor before running.
+- `--no-edit`: skip edit prompt and run/cancel only.
+- `DATAVIZHUB_WIZARD_EDITOR_MODE`: `always`, `never`, or `prompt` (default).
+
+Editor behavior
+- If `prompt_toolkit` is available: inline multi‑line edit buffer.
+- Else: `$VISUAL`/`$EDITOR` is used if set; otherwise a simple stdin multi‑line prompt.
+
+Install
+- `poetry install -E wizard` or `pip install 'datavizhub[wizard]'`.
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -2522,11 +2522,12 @@ version = "3.0.51"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07"},
     {file = "prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed"},
 ]
+markers = {main = "extra == \"wizard\" or extra == \"all\""}
 
 [package.dependencies]
 wcwidth = "*"
@@ -4007,11 +4008,12 @@ version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
+markers = {main = "extra == \"wizard\" or extra == \"all\""}
 
 [[package]]
 name = "websockets"
@@ -4228,7 +4230,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [extras]
-all = ["PyVimeo", "boto3", "cartopy", "cfgrib", "fastapi", "ffmpeg-python", "matplotlib", "netcdf4", "pygrib", "python-magic", "python-multipart", "rasterio", "redis", "requests", "rioxarray", "rq", "scipy", "siphon", "uvicorn", "xarray"]
+all = ["PyVimeo", "boto3", "cartopy", "cfgrib", "fastapi", "ffmpeg-python", "matplotlib", "netcdf4", "prompt_toolkit", "pygrib", "python-magic", "python-multipart", "rasterio", "redis", "requests", "rioxarray", "rq", "scipy", "siphon", "uvicorn", "xarray"]
 api = ["fastapi", "python-multipart", "redis", "rq", "uvicorn"]
 connectors = ["PyVimeo", "boto3", "requests"]
 datatransfer = ["PyVimeo", "boto3", "requests"]
@@ -4239,9 +4241,10 @@ mime = ["python-magic"]
 netcdf = ["netcdf4", "xarray"]
 processing = ["cfgrib", "ffmpeg-python", "netcdf4", "pygrib", "rasterio", "rioxarray", "scipy", "siphon", "xarray"]
 visualization = ["cartopy", "matplotlib", "scipy", "xarray"]
+wizard = ["prompt_toolkit"]
 ws = ["websockets"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "307609c89b850cd330090bef8b99573c4c544089e0ecced91a1250c36f79592c"
+content-hash = "fdaa8e6fba925f3c23dbdbf494775995c6f763cfa957ddfb5c90de3cfefc6ffc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "A tool to ingest data from various sources and formats, create im
 authors = ["Eric Hackathorn <eric.j.hackathorn@noaa.gov>"]
 include = [
     "src/datavizhub/assets/**",
+    "src/datavizhub/wizard/*.json",
 ]
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ redis = { version = "^5.0.0", optional = true }
 rq = { version = "^1.15.1", optional = true }
 python-magic = { version = "^0.4.27", optional = true }
 websockets = { version = "^11.0.3", optional = true }
+prompt_toolkit = { version = "^3.0.50", optional = true }
 
 # Optional feature dependencies (installed via extras)
 boto3 = { version = "^1.17", optional = true }
@@ -106,6 +107,11 @@ interactive = [
     "plotly",
 ]
 
+# Wizard REPL (optional)
+wizard = [
+    "prompt_toolkit",
+]
+
 # Focused extras for targeted installs
 grib2 = [
     "cfgrib",
@@ -147,6 +153,8 @@ all = [
     "redis",
     "rq",
     "python-magic",
+    # Wizard UX
+    "prompt_toolkit",
 ]
 
 # Optional MIME type detection

--- a/src/datavizhub/cli.py
+++ b/src/datavizhub/cli.py
@@ -560,9 +560,9 @@ def main(argv: list[str] | None = None) -> int:
         import datavizhub.transform as _transform_mod
         from datavizhub import processing as _process_mod
         from datavizhub import visualization as _visual_mod
+        from datavizhub import wizard as _wizard_mod
         from datavizhub.connectors import egress as _egress_mod
         from datavizhub.connectors import ingest as _ingest_mod
-        from datavizhub import wizard as _wizard_mod
         from datavizhub.wizard.manifest import save_manifest as _save_manifest
 
         p_acq = sub.add_parser("acquire", help="Acquire/ingest data from sources")

--- a/src/datavizhub/cli.py
+++ b/src/datavizhub/cli.py
@@ -525,6 +525,36 @@ def main(argv: list[str] | None = None) -> int:
     elif first_non_flag == "run":
         # Already registered above
         pass
+    elif first_non_flag == "wizard":
+        # Lightweight: registers a single command with optional LLM backends
+        from datavizhub import wizard as _wizard_mod
+
+        p_wiz = sub.add_parser(
+            "wizard", help="Interactive assistant that suggests/runs CLI commands"
+        )
+        _wizard_mod.register_cli(p_wiz)
+    elif first_non_flag == "generate-manifest":
+        # Developer utility to generate capabilities manifest
+        from datavizhub.wizard.manifest import save_manifest as _save_manifest
+
+        p_gen = sub.add_parser(
+            "generate-manifest", help="Generate capabilities JSON manifest"
+        )
+        p_gen.add_argument(
+            "-o",
+            "--output",
+            default=str(
+                Path(__file__).parent / "wizard" / "datavizhub_capabilities.json"
+            ),
+            help="Output path for capabilities manifest JSON",
+        )
+
+        def _cmd_gen(ns: argparse.Namespace) -> int:
+            _save_manifest(ns.output)
+            print(ns.output)
+            return 0
+
+        p_gen.set_defaults(func=_cmd_gen)
     else:
         # Fallback: register the full CLI tree when we cannot infer the target
         import datavizhub.transform as _transform_mod
@@ -532,6 +562,8 @@ def main(argv: list[str] | None = None) -> int:
         from datavizhub import visualization as _visual_mod
         from datavizhub.connectors import egress as _egress_mod
         from datavizhub.connectors import ingest as _ingest_mod
+        from datavizhub import wizard as _wizard_mod
+        from datavizhub.wizard.manifest import save_manifest as _save_manifest
 
         p_acq = sub.add_parser("acquire", help="Acquire/ingest data from sources")
         acq_sub = p_acq.add_subparsers(dest="acquire_cmd", required=True)
@@ -558,6 +590,32 @@ def main(argv: list[str] | None = None) -> int:
         p_tr = sub.add_parser("transform", help="Transform helpers (metadata, etc.)")
         tr_sub = p_tr.add_subparsers(dest="transform_cmd", required=True)
         _transform_mod.register_cli(tr_sub)
+
+        # Wizard (single command, no subcommands)
+        p_wiz = sub.add_parser(
+            "wizard", help="Interactive assistant that suggests/runs CLI commands"
+        )
+        _wizard_mod.register_cli(p_wiz)
+
+        # Generate-manifest
+        p_gen = sub.add_parser(
+            "generate-manifest", help="Generate capabilities JSON manifest"
+        )
+        p_gen.add_argument(
+            "-o",
+            "--output",
+            default=str(
+                Path(__file__).parent / "wizard" / "datavizhub_capabilities.json"
+            ),
+            help="Output path for capabilities manifest JSON",
+        )
+
+        def _cmd_gen(ns: argparse.Namespace) -> int:
+            _save_manifest(ns.output)
+            print(ns.output)
+            return 0
+
+        p_gen.set_defaults(func=_cmd_gen)
 
     args = parser.parse_args(args_list)
     return args.func(args)

--- a/src/datavizhub/wizard/__init__.py
+++ b/src/datavizhub/wizard/__init__.py
@@ -315,19 +315,19 @@ class _WizardCompleter(Completer):  # type: ignore[misc]
         self.options: set[str] = toks["options"]
         self.opt_map: dict[tuple[str, str | None], set[str]] = toks["opt_map"]
         self.path_like: set[str] = toks.get("path_like", set())
-        self.opt_choices: dict[
-            tuple[str, str | None], dict[str, set[str]]
-        ] = toks.get("opt_choices", {})
+        self.opt_choices: dict[tuple[str, str | None], dict[str, set[str]]] = toks.get(
+            "opt_choices", {}
+        )
         self.choices_global: dict[str, set[str]] = toks.get("choices_global", {})
-        self.opt_meta: dict[
-            tuple[str, str | None], dict[str, dict]
-        ] = toks.get("opt_meta", {})
-        self.group_map: dict[
-            tuple[str, str | None], dict[str, str]
-        ] = toks.get("group_map", {})
-        self.group_order: dict[
-            tuple[str, str | None], dict[str, int]
-        ] = toks.get("group_order", {})
+        self.opt_meta: dict[tuple[str, str | None], dict[str, dict]] = toks.get(
+            "opt_meta", {}
+        )
+        self.group_map: dict[tuple[str, str | None], dict[str, str]] = toks.get(
+            "group_map", {}
+        )
+        self.group_order: dict[tuple[str, str | None], dict[str, int]] = toks.get(
+            "group_order", {}
+        )
         self.path_completer = PathCompleter(expanduser=True)  # type: ignore
 
     def _iter_basic(self, last: str, word: str):
@@ -353,6 +353,7 @@ class _WizardCompleter(Completer):  # type: ignore[misc]
             for w in self._iter_basic(self.first_tokens, current):
                 yield Completion(w, start_position=-len(current))  # type: ignore
             return
+
         # After first token, try subcommands and options
         # If typing an option, complete from options
         def _meta_for_option(opt_name: str) -> dict:
@@ -461,6 +462,7 @@ class _WizardCompleter(Completer):  # type: ignore[misc]
             # Delegate to PathCompleter
             yield from self.path_completer.get_completions(document, complete_event)  # type: ignore
             return
+
         # If previous token is an option with choices, suggest its choices
         def _choices_for_option(opt_name: str) -> set[str]:
             second = parts[1] if len(parts) >= 2 else None

--- a/src/datavizhub/wizard/__init__.py
+++ b/src/datavizhub/wizard/__init__.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+import uuid
+import json
+from importlib import resources
+from pathlib import Path
+from typing import Iterable, List
+
+from .llm_client import LLMClient, OllamaClient, OpenAIClient, MockClient
+
+
+@dataclass
+class SessionState:
+    last_file: str | None = None
+    history: list[str] = field(default_factory=list)
+    session_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+
+def _load_config() -> dict:
+    """Load wizard config from ~/.datavizhub_wizard.yaml if present.
+
+    Keys supported:
+    - provider: "openai" | "ollama" | "mock"
+    - model: model name string
+    """
+    import yaml  # type: ignore
+
+    path = os.path.expanduser("~/.datavizhub_wizard.yaml")
+    try:
+        if not os.path.exists(path):
+            return {}
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        if not isinstance(data, dict):
+            return {}
+        return {str(k): v for k, v in data.items()}
+    except Exception:
+        return {}
+
+
+def _select_provider(provider: str | None, model: str | None) -> LLMClient:
+    cfg = _load_config()
+    prov = (
+        provider
+        or os.environ.get("DATAVIZHUB_LLM_PROVIDER")
+        or cfg.get("provider")
+        or "openai"
+    )
+    prov = str(prov).lower()
+    model_name = (
+        model
+        or os.environ.get("DATAVIZHUB_LLM_MODEL")
+        or cfg.get("model")
+        or None
+    )
+    if prov == "openai":
+        return OpenAIClient(model=model_name)
+    if prov == "ollama":
+        return OllamaClient(model=model_name)
+    if prov == "mock":
+        return MockClient()
+    # Fallback to mock for unknown providers
+    return MockClient()
+
+
+SYSTEM_PROMPT = (
+    "You are DataVizHub Wizard, an assistant that helps users run the "
+    "'datavizhub' CLI. Your job is to output one or more CLI commands "
+    "that directly accomplish the user's request.\n\n"
+    "Formatting rules:\n"
+    "- Always wrap commands in a fenced code block with 'bash'.\n"
+    "- Each command must start with 'datavizhub'.\n"
+    "- If multiple steps are needed, put each on its own line.\n"
+    "- You may include short inline comments (using #) to briefly explain "
+    "what each command does.\n"
+    "- Do not include any text outside the fenced code block.\n\n"
+    "Guidelines:\n"
+    "- Prefer succinct, directly runnable commands.\n"
+    "- Use placeholders (like <input-file>) only when unavoidable.\n"
+    "- Never generate non-datavizhub shell commands (e.g., rm, curl, sudo).\n"
+    "- If essential details are missing, make a reasonable assumption and use a placeholder.\n"
+    "- Explanations should be one short phrase only, never long sentences.\n"
+    "- Avoid redundant flags unless necessary for clarity.\n\n"
+    "Your output must always be a single fenced code block with commands "
+    "and optional short comments."
+)
+
+_CAP_MANIFEST_CACHE: dict | None = None
+
+
+def _load_capabilities_manifest() -> dict | None:
+    global _CAP_MANIFEST_CACHE
+    if _CAP_MANIFEST_CACHE is not None:
+        return _CAP_MANIFEST_CACHE
+    try:
+        with resources.files(__package__).joinpath(
+            "datavizhub_capabilities.json"
+        ).open("r", encoding="utf-8") as f:
+            _CAP_MANIFEST_CACHE = json.load(f)
+            return _CAP_MANIFEST_CACHE
+    except Exception:
+        _CAP_MANIFEST_CACHE = None
+        return None
+
+
+def _select_relevant_capabilities(prompt: str, cap: dict, limit: int = 6) -> list[str]:
+    text = prompt.lower()
+    scored: list[tuple[int, str, dict]] = []
+    for cmd, meta in cap.items():
+        desc = str(meta.get("description") or "").lower()
+        opts = " ".join(meta.get("options", {}).keys()).lower()
+        hay = f"{cmd.lower()} {desc} {opts}"
+        score = 0
+        for token in set(text.replace("/", " ").replace(",", " ").split()):
+            if token and token in hay:
+                score += 1
+        if score:
+            scored.append((score, cmd, meta))
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    out = []
+    for _, cmd, meta in scored[:limit]:
+        opts = ", ".join(meta.get("options", {}).keys())
+        desc = meta.get("description", "")
+        out.append(f"- {cmd}: {desc} Options: {opts}".strip())
+    return out
+
+
+
+def _strip_inline_comment(s: str) -> str:
+    """Strip inline '#' comments that are outside quotes.
+
+    Keeps content inside single or double quotes intact; stops at the first
+    unquoted '#'. This is a best-effort sanitizer for LLM explanations.
+    """
+    out = []
+    in_single = False
+    in_double = False
+    escape = False
+    for ch in s:
+        if escape:
+            out.append(ch)
+            escape = False
+            continue
+        if ch == "\\":
+            out.append(ch)
+            escape = True
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            out.append(ch)
+            continue
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            out.append(ch)
+            continue
+        if ch == "#" and not in_single and not in_double:
+            break  # start of comment
+        out.append(ch)
+    return "".join(out).rstrip()
+
+
+def _extract_annotated_commands(text: str) -> list[str]:
+    """Extract datavizhub command lines from LLM text.
+
+    Strategy:
+    - Prefer fenced code blocks; support both `datavizhub ...` and `$ datavizhub ...` forms.
+    - If none found in fences, scan whole text for the same patterns.
+    - Return each command line as a separate string without shell prompts.
+    """
+    def _normalize_cmd(line: str) -> str | None:
+        s = line.strip()
+        if not s or s.startswith("#"):
+            return None
+        # Strip common shell prompt prefixes like `$ ` or `> `
+        if s.startswith("$"):
+            s = s[1:].lstrip()
+        if s.startswith(">"):
+            s = s[1:].lstrip()
+        return s if s.startswith("datavizhub ") else None
+
+    cmds: list[str] = []
+    # Find fenced code blocks first
+    code_blocks = re.findall(r"```[a-zA-Z0-9_-]*\n(.*?)```", text, flags=re.S)
+    for block in code_blocks:
+        for line in block.splitlines():
+            s = _normalize_cmd(line)
+            if s:
+                cmds.append(s)
+    # Fallback: scan lines outside of code fences
+    if not cmds:
+        for line in text.splitlines():
+            s = _normalize_cmd(line)
+            if s:
+                cmds.append(s)
+    return cmds
+
+
+def _confirm(prompt: str, assume_yes: bool = False) -> bool:
+    if assume_yes:
+        return True
+    try:
+        ans = input(prompt + " [y/N]: ").strip().lower()
+        return ans in ("y", "yes")
+    except EOFError:
+        return False
+
+
+def _run_one(cmd: str) -> int:
+    """Execute a single datavizhub command by calling the internal CLI."""
+    from datavizhub.cli import main as cli_main
+
+    # Strip leading program name if present
+    parts = shlex.split(cmd)
+    if parts and parts[0] == "datavizhub":
+        parts = parts[1:]
+    try:
+        return int(cli_main(parts))
+    except SystemExit as exc:  # if cli_main raises SystemExit
+        return int(getattr(exc, "code", 1) or 0)
+
+
+def _ensure_log_dir() -> Path:
+    root = Path(os.path.expanduser("~/.datavizhub/wizard_logs"))
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _log_event(logfile: Path | None, event: dict, *, session_id: str | None = None) -> None:
+    if logfile is None:
+        return
+    try:
+        # Enrich with schema + correlation IDs
+        event = dict(event)
+        event.setdefault("schema_version", 1)
+        if session_id:
+            event.setdefault("session_id", session_id)
+        event.setdefault("event_id", uuid.uuid4().hex)
+        with logfile.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+
+def _handle_prompt(
+    prompt: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    dry_run: bool,
+    assume_yes: bool,
+    max_commands: int | None,
+    logfile: Path | None,
+    log_raw_llm: bool = False,
+    show_raw: bool = False,
+    explain: bool = False,
+    session: SessionState | None = None,
+) -> int:
+    client = _select_provider(provider, model)
+    # Build contextual user prompt for LLM if session is provided
+    user_prompt = prompt
+    if session is not None and (session.last_file or session.history):
+        ctx_lines = ["Context:"]
+        if session.last_file:
+            ctx_lines.append(f"- Last file: {session.last_file}")
+        if session.history:
+            recent = session.history[-5:]
+            ctx_lines.append("- Recent commands:")
+            for c in recent:
+                ctx_lines.append(f"  - {c}")
+        # Capabilities: prepend relevant commands from manifest
+        cap = _load_capabilities_manifest()
+        if cap:
+            rel = _select_relevant_capabilities(prompt, cap)
+            if rel:
+                ctx_lines.append("- Relevant commands:")
+                ctx_lines.extend(f"  {line}" for line in rel)
+        ctx_lines.append("")
+        ctx_lines.append("Task:")
+        ctx_lines.append(prompt)
+        user_prompt = "\n".join(ctx_lines)
+    provider_name = getattr(client, "name", client.__class__.__name__)
+    model_name = getattr(client, "model", None)
+    _log_event(
+        logfile,
+        {
+            "ts": datetime.utcnow().isoformat() + "Z",
+            "type": "user_prompt",
+            "prompt": prompt,
+            "provider": provider_name,
+            "model": model_name,
+        },
+        session_id=(session.session_id if session else None),
+    )
+
+    reply = client.generate(SYSTEM_PROMPT, user_prompt)
+    if log_raw_llm:
+        _log_event(
+            logfile,
+            {
+                "ts": datetime.utcnow().isoformat() + "Z",
+                "type": "assistant_reply",
+                "text": reply,
+                "raw": reply,
+                "provider": provider_name,
+                "model": model_name,
+            },
+            session_id=(session.session_id if session else None),
+        )
+
+    annotated_cmds = _extract_annotated_commands(reply)
+    # Normalize by stripping comments while keeping only datavizhub lines
+    cmds = []
+    for a in annotated_cmds:
+        s = _strip_inline_comment(a)
+        if s.startswith("datavizhub "):
+            cmds.append(s)
+    # Strict safety: drop any lines that don't start with datavizhub
+    safe_cmds = [c for c in cmds if c.startswith("datavizhub ")]
+    dropped = len(cmds) - len(safe_cmds)
+    if dropped > 0:
+        print(f"[safe] Ignored {dropped} non-datavizhub line(s).")
+    cmds = safe_cmds
+    if max_commands is not None:
+        cmds = cmds[: max(0, int(max_commands))]
+
+    if not cmds:
+        print("No datavizhub commands were suggested.")
+        return 1
+
+    # Show raw LLM output if requested (debug aid before parsing)
+    if show_raw:
+        print("Raw model output:\n" + reply)
+    # Suggested commands: optionally include inline comments via annotated lines
+    if explain:
+        shown = [a for a in annotated_cmds if a.startswith("datavizhub ")]
+        print("Suggested commands (with explanations):\n" + "\n".join(f"  {c}" for c in shown))
+    else:
+        print("Suggested commands:\n" + "\n".join(f"  {c}" for c in cmds))
+    # Update session context immediately so dry-runs can influence follow-up prompts
+    if session is not None:
+        session.history.extend(cmds if not explain else shown)
+        last_out = None
+        for c in cmds:
+            m = re.findall(r"(?:--output|-o)\s+(\S+)", c)
+            if m:
+                last_out = m[-1]
+        if last_out:
+            session.last_file = last_out
+    if dry_run:
+        _log_event(
+            logfile,
+            {
+                "ts": datetime.utcnow().isoformat() + "Z",
+                "type": "dry_run",
+                "commands": cmds,
+                "provider": provider_name,
+                "model": model_name,
+            },
+            session_id=(session.session_id if session else None),
+        )
+        return 0
+    if not _confirm("Execute these commands?", assume_yes):
+        return 0
+
+    status = 0
+    for c in cmds:
+        print(f"\n$ {c}")
+        rc = _run_one(c)
+        _log_event(
+            logfile,
+            {
+                "ts": datetime.utcnow().isoformat() + "Z",
+                "type": "exec",
+                "cmd": c,
+                "returncode": rc,
+                "ok": (rc == 0),
+                "provider": provider_name,
+                "model": model_name,
+            },
+            session_id=(session.session_id if session else None),
+        )
+        if rc != 0:
+            print(f"Command failed with exit code {rc}")
+            status = rc
+            break
+    _log_event(
+        logfile,
+        {
+            "ts": datetime.utcnow().isoformat() + "Z",
+            "type": "result",
+            "returncode": status,
+            "ok": (status == 0),
+            "commands": cmds,
+            "provider": provider_name,
+            "model": model_name,
+        },
+        session_id=(session.session_id if session else None),
+    )
+    # Session was already updated above; nothing further needed here.
+    return status
+
+
+def _interactive_loop(args: argparse.Namespace) -> int:
+    print("Welcome to DataVizHub Wizard! Type 'exit' to quit.")
+    session = SessionState()
+    logfile = None
+    if args.log:
+        logdir = _ensure_log_dir()
+        logfile = logdir / (datetime.utcnow().strftime("%Y%m%dT%H%M%SZ") + ".jsonl")
+    while True:
+        try:
+            q = input("> ").strip()
+        except EOFError:
+            print()
+            return 0
+        if not q:
+            continue
+        if q.lower() in {"exit", "quit"}:
+            return 0
+        rc = _handle_prompt(
+            q,
+            provider=args.provider,
+            model=args.model,
+            dry_run=args.dry_run,
+            assume_yes=args.yes,
+            max_commands=args.max_commands,
+            logfile=logfile,
+            log_raw_llm=getattr(args, "log_raw_llm", False),
+            show_raw=getattr(args, "show_raw", False),
+            explain=getattr(args, "explain", False),
+            session=session,
+        )
+        if rc != 0:
+            print(f"Last command set exited with {rc}")
+
+
+def register_cli(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--prompt",
+        help="One-shot query to generate CLI commands; start interactive mode if omitted",
+    )
+    p.add_argument(
+        "--provider",
+        choices=["openai", "ollama", "mock"],
+        help="LLM provider (default: openai)",
+    )
+    p.add_argument("--model", help="Model name override for the selected provider")
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show suggested commands but do not execute",
+    )
+    p.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Auto-confirm execution without prompting",
+    )
+    p.add_argument(
+        "--max-commands",
+        type=int,
+        help="Limit number of suggested commands to run",
+    )
+    p.add_argument(
+        "--log",
+        action="store_true",
+        help="Log prompts, replies, and executions to ~/.datavizhub/wizard_logs",
+    )
+    p.add_argument(
+        "--log-raw-llm",
+        action="store_true",
+        help="Include full raw LLM responses in logs (assistant_reply events)",
+    )
+    p.add_argument(
+        "--show-raw",
+        action="store_true",
+        help="Print the full raw LLM output before parsing",
+    )
+    p.add_argument(
+        "--explain",
+        action="store_true",
+        help="Show inline # comments in suggested commands (preview only)",
+    )
+
+    def _cmd(ns: argparse.Namespace) -> int:
+        if ns.prompt:
+            logfile = None
+            if ns.log:
+                logdir = _ensure_log_dir()
+                logfile = logdir / (
+                    datetime.utcnow().strftime("%Y%m%dT%H%M%SZ") + ".jsonl"
+                )
+            # One-shot: create a transient session for correlation IDs
+            the_session = SessionState()
+            return _handle_prompt(
+                ns.prompt,
+                provider=ns.provider,
+                model=ns.model,
+                dry_run=ns.dry_run,
+                assume_yes=ns.yes,
+                max_commands=ns.max_commands,
+                logfile=logfile,
+                log_raw_llm=ns.log_raw_llm,
+                show_raw=ns.show_raw,
+                explain=ns.explain,
+                session=the_session,
+            )
+        return _interactive_loop(ns)
+
+    p.set_defaults(func=_cmd)

--- a/src/datavizhub/wizard/__init__.py
+++ b/src/datavizhub/wizard/__init__.py
@@ -13,6 +13,11 @@ from pathlib import Path
 
 from .llm_client import LLMClient, MockClient, OllamaClient, OpenAIClient
 
+try:
+    import yaml  # type: ignore
+except Exception:
+    yaml = None  # type: ignore[assignment]
+
 
 @dataclass
 class SessionState:
@@ -28,10 +33,10 @@ def _load_config() -> dict:
     - provider: "openai" | "ollama" | "mock"
     - model: model name string
     """
-    import yaml  # type: ignore
-
     path = Path("~/.datavizhub_wizard.yaml").expanduser()
     try:
+        if yaml is None:
+            return {}
         if not path.exists():
             return {}
         with path.open("r", encoding="utf-8") as f:

--- a/src/datavizhub/wizard/datavizhub_capabilities.json
+++ b/src/datavizhub/wizard/datavizhub_capabilities.json
@@ -1,108 +1,424 @@
 {
   "acquire http": {
     "description": "datavizhub acquire http",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--output",
+          "--list",
+          "--pattern",
+          "--since",
+          "--since-period",
+          "--until",
+          "--date-format",
+          "--inputs",
+          "--manifest",
+          "--output-dir"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--output": "Output path or '-' for stdout",
-      "--list": "List links on a directory page",
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path",
+        "default": "-"
+      },
+      "--list": {
+        "help": "List links on a directory page",
+        "type": "str",
+        "default": false
+      },
       "--pattern": "Regex to filter listed links",
       "--since": "ISO date filter for list mode",
       "--since-period": "ISO-8601 duration for lookback (e.g., P1Y, P6M, P7D, PT24H)",
       "--until": "ISO date filter for list mode",
       "--date-format": "Filename date format for list filtering (e.g., YYYYMMDD)",
-      "--inputs": "Multiple HTTP URLs to fetch",
-      "--manifest": "Path to a file listing URLs (one per line)",
-      "--output-dir": "Directory to write outputs for --inputs"
+      "--inputs": {
+        "help": "Multiple HTTP URLs to fetch",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--manifest": {
+        "help": "Path to a file listing URLs (one per line)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output-dir": {
+        "help": "Directory to write outputs for --inputs",
+        "path_arg": true,
+        "type": "path"
+      }
     }
   },
   "acquire s3": {
     "description": "datavizhub acquire s3",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--url",
+          "--bucket",
+          "--key",
+          "--unsigned",
+          "--list",
+          "--pattern",
+          "--since",
+          "--since-period",
+          "--until",
+          "--date-format",
+          "--inputs",
+          "--manifest",
+          "--output-dir",
+          "--output"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
       "--url": "Full URL s3://bucket/key",
       "--bucket": "Bucket name",
       "--key": "Object key (when using --bucket)",
-      "--unsigned": "Use unsigned access for public buckets",
-      "--list": "List keys under a prefix",
+      "--unsigned": {
+        "help": "Use unsigned access for public buckets",
+        "type": "str",
+        "default": false
+      },
+      "--list": {
+        "help": "List keys under a prefix",
+        "type": "str",
+        "default": false
+      },
       "--pattern": "Regex to filter listed keys",
       "--since": "ISO date filter for list mode",
       "--since-period": "ISO-8601 duration for lookback (e.g., P1Y, P6M, P7D, PT24H)",
       "--until": "ISO date filter for list mode",
       "--date-format": "Filename date format for list filtering (e.g., YYYYMMDD)",
-      "--inputs": "Multiple s3:// URLs to fetch",
-      "--manifest": "Path to a file listing s3:// URLs (one per line)",
-      "--output-dir": "Directory to write outputs for --inputs",
-      "--output": "Output path or '-' for stdout"
+      "--inputs": {
+        "help": "Multiple s3:// URLs to fetch",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--manifest": {
+        "help": "Path to a file listing s3:// URLs (one per line)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output-dir": {
+        "help": "Directory to write outputs for --inputs",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path",
+        "default": "-"
+      }
     }
   },
   "acquire ftp": {
     "description": "datavizhub acquire ftp",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--output",
+          "--list",
+          "--sync-dir",
+          "--pattern",
+          "--since",
+          "--since-period",
+          "--until",
+          "--date-format",
+          "--inputs",
+          "--manifest",
+          "--output-dir"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--output": "Output path or '-' for stdout",
-      "--list": "List files in an FTP directory",
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path",
+        "default": "-"
+      },
+      "--list": {
+        "help": "List files in an FTP directory",
+        "type": "str",
+        "default": false
+      },
       "--sync-dir": "Sync FTP directory to a local directory",
       "--pattern": "Regex to filter list/sync",
       "--since": "ISO date filter for list/sync",
       "--since-period": "ISO-8601 duration for lookback (e.g., P1Y, P6M, P7D, PT24H)",
       "--until": "ISO date filter for list/sync",
       "--date-format": "Filename date format for filtering (e.g., YYYYMMDD)",
-      "--inputs": "Multiple FTP paths to fetch",
-      "--manifest": "Path to a file listing FTP paths (one per line)",
-      "--output-dir": "Directory to write outputs for --inputs"
+      "--inputs": {
+        "help": "Multiple FTP paths to fetch",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--manifest": {
+        "help": "Path to a file listing FTP paths (one per line)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output-dir": {
+        "help": "Directory to write outputs for --inputs",
+        "path_arg": true,
+        "type": "path"
+      }
     }
   },
   "acquire vimeo": {
     "description": "datavizhub acquire vimeo",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--output"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--output": "Output path or '-' for stdout"
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path",
+        "default": "-"
+      }
     }
   },
   "process decode-grib2": {
     "description": "datavizhub process decode-grib2",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--backend",
+          "--pattern",
+          "--unsigned",
+          "--raw"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--backend": "",
+      "--backend": {
+        "help": "",
+        "choices": [
+          "cfgrib",
+          "pygrib",
+          "wgrib2"
+        ],
+        "type": "str",
+        "default": "cfgrib"
+      },
       "--pattern": "Regex for .idx-based subsetting when using HTTP/S3",
-      "--unsigned": "Use unsigned S3 access for public buckets",
-      "--raw": "Emit raw (optionally .idx-subset) GRIB2 bytes to stdout"
+      "--unsigned": {
+        "help": "Use unsigned S3 access for public buckets",
+        "type": "str",
+        "default": false
+      },
+      "--raw": {
+        "help": "Emit raw (optionally .idx-subset) GRIB2 bytes to stdout",
+        "type": "str",
+        "default": false
+      }
     }
   },
   "process extract-variable": {
     "description": "datavizhub process extract-variable",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--backend",
+          "--stdout",
+          "--format"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--backend": "",
-      "--stdout": "Write selected variable as bytes to stdout",
-      "--format": "Output format for --stdout"
+      "--backend": {
+        "help": "",
+        "choices": [
+          "xarray",
+          "pygrib"
+        ],
+        "type": "str",
+        "default": "xarray"
+      },
+      "--stdout": {
+        "help": "Write selected variable as bytes to stdout",
+        "type": "str",
+        "default": false
+      },
+      "--format": {
+        "help": "Output format for --stdout",
+        "choices": [
+          "npy",
+          "nc",
+          "grib2"
+        ],
+        "type": "str",
+        "default": "npy"
+      }
     }
   },
   "process convert-format": {
     "description": "datavizhub process convert-format",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--output",
+          "--stdout",
+          "--inputs",
+          "--output-dir",
+          "--backend",
+          "--var",
+          "--pattern",
+          "--unsigned"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--output": "",
-      "--stdout": "Write binary output to stdout instead of a file",
-      "--inputs": "Multiple input paths or URLs",
-      "--output-dir": "Directory to write outputs for --inputs",
-      "--backend": "",
+      "--output": {
+        "help": "",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--stdout": {
+        "help": "Write binary output to stdout instead of a file",
+        "type": "str",
+        "default": false
+      },
+      "--inputs": {
+        "help": "Multiple input paths or URLs",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output-dir": {
+        "help": "Directory to write outputs for --inputs",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--backend": {
+        "help": "",
+        "choices": [
+          "xarray",
+          "pygrib",
+          "pydap"
+        ],
+        "type": "str",
+        "default": "xarray"
+      },
       "--var": "Variable name or regex for multi-var datasets",
       "--pattern": "Regex for .idx-based subsetting when using HTTP/S3",
-      "--unsigned": "Use unsigned S3 access for public buckets"
+      "--unsigned": {
+        "help": "Use unsigned S3 access for public buckets",
+        "type": "str",
+        "default": false
+      }
     }
   },
   "visualize heatmap": {
     "description": "datavizhub visualize heatmap",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input",
+          "--var",
+          "--basemap",
+          "--extent",
+          "--output",
+          "--inputs",
+          "--output-dir",
+          "--width",
+          "--height",
+          "--dpi",
+          "--cmap",
+          "--colorbar",
+          "--label",
+          "--units",
+          "--features",
+          "--xarray-engine",
+          "--map-type",
+          "--tile-source",
+          "--tile-zoom",
+          "--timestamp",
+          "--crs",
+          "--reproject",
+          "--timestamp-loc",
+          "--no-coastline",
+          "--no-borders",
+          "--no-gridlines"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Path to .nc or .npy input",
+      "--input": {
+        "help": "Path to .nc or .npy input",
+        "path_arg": true,
+        "type": "path"
+      },
       "--var": "Variable name for NetCDF inputs",
-      "--basemap": "Path to background image",
+      "--basemap": {
+        "help": "Path to background image",
+        "path_arg": true,
+        "type": "path"
+      },
       "--extent": "west east south north",
-      "--output": "Output PNG path (required when using --input; for --inputs use --output-dir)",
-      "--inputs": "Multiple input paths for batch rendering",
-      "--output-dir": "Directory to write outputs for --inputs",
+      "--output": {
+        "help": "Output PNG path (required when using --input; for --inputs use --output-dir)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--inputs": {
+        "help": "Multiple input paths for batch rendering",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output-dir": {
+        "help": "Directory to write outputs for --inputs",
+        "path_arg": true,
+        "type": "path"
+      },
       "--width": "",
       "--height": "",
       "--dpi": "",
@@ -126,15 +442,73 @@
   },
   "visualize contour": {
     "description": "datavizhub visualize contour",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input",
+          "--inputs",
+          "--output-dir",
+          "--var",
+          "--basemap",
+          "--extent",
+          "--output",
+          "--width",
+          "--height",
+          "--dpi",
+          "--cmap",
+          "--filled",
+          "--levels",
+          "--colorbar",
+          "--label",
+          "--units",
+          "--features",
+          "--xarray-engine",
+          "--map-type",
+          "--tile-source",
+          "--tile-zoom",
+          "--timestamp",
+          "--crs",
+          "--reproject",
+          "--timestamp-loc",
+          "--no-coastline",
+          "--no-borders",
+          "--no-gridlines"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Path to .nc or .npy input",
-      "--inputs": "Multiple inputs for batch rendering",
-      "--output-dir": "Directory to write outputs for --inputs",
+      "--input": {
+        "help": "Path to .nc or .npy input",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--inputs": {
+        "help": "Multiple inputs for batch rendering",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output-dir": {
+        "help": "Directory to write outputs for --inputs",
+        "path_arg": true,
+        "type": "path"
+      },
       "--var": "Variable name for NetCDF inputs",
-      "--basemap": "Path to background image",
+      "--basemap": {
+        "help": "Path to background image",
+        "path_arg": true,
+        "type": "path"
+      },
       "--extent": "west east south north",
-      "--output": "Output PNG path (required for single --input; when using --inputs, prefer --output-dir)",
+      "--output": {
+        "help": "Output PNG path (required for single --input; when using --inputs, prefer --output-dir)",
+        "path_arg": true,
+        "type": "path"
+      },
       "--width": "",
       "--height": "",
       "--dpi": "",
@@ -160,13 +534,43 @@
   },
   "visualize timeseries": {
     "description": "datavizhub visualize timeseries",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input",
+          "--x",
+          "--y",
+          "--var",
+          "--output",
+          "--width",
+          "--height",
+          "--dpi",
+          "--title",
+          "--xlabel",
+          "--ylabel",
+          "--style"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Path to .csv or .nc input",
+      "--input": {
+        "help": "Path to .csv or .nc input",
+        "path_arg": true,
+        "type": "path"
+      },
       "--x": "CSV: X column name (e.g., time)",
       "--y": "CSV: Y column name (value)",
       "--var": "NetCDF: variable name to plot",
-      "--output": "Output PNG path",
+      "--output": {
+        "help": "Output PNG path",
+        "path_arg": true,
+        "type": "path"
+      },
       "--width": "",
       "--height": "",
       "--dpi": "",
@@ -178,18 +582,83 @@
   },
   "visualize vector": {
     "description": "datavizhub visualize vector",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input",
+          "--inputs",
+          "--output-dir",
+          "--uvar",
+          "--vvar",
+          "--u",
+          "--v",
+          "--basemap",
+          "--extent",
+          "--output",
+          "--width",
+          "--height",
+          "--dpi",
+          "--density",
+          "--scale",
+          "--color",
+          "--features",
+          "--xarray-engine",
+          "--map-type",
+          "--tile-source",
+          "--tile-zoom",
+          "--streamlines",
+          "--crs",
+          "--reproject",
+          "--no-coastline",
+          "--no-borders",
+          "--no-gridlines"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Path to .nc input (alternative to --u/--v .npy)",
-      "--inputs": "Multiple inputs for batch rendering",
-      "--output-dir": "Directory to write outputs for --inputs",
+      "--input": {
+        "help": "Path to .nc input (alternative to --u/--v .npy)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--inputs": {
+        "help": "Multiple inputs for batch rendering",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output-dir": {
+        "help": "Directory to write outputs for --inputs",
+        "path_arg": true,
+        "type": "path"
+      },
       "--uvar": "NetCDF: U variable name",
       "--vvar": "NetCDF: V variable name",
-      "--u": "Path to U .npy file (alternative input)",
-      "--v": "Path to V .npy file (alternative input)",
-      "--basemap": "Path to background image",
+      "--u": {
+        "help": "Path to U .npy file (alternative input)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--v": {
+        "help": "Path to V .npy file (alternative input)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--basemap": {
+        "help": "Path to background image",
+        "path_arg": true,
+        "type": "path"
+      },
       "--extent": "west east south north",
-      "--output": "Output PNG path (required for single --input/--u/--v; when using --inputs, prefer --output-dir)",
+      "--output": {
+        "help": "Output PNG path (required for single --input/--u/--v; when using --inputs, prefer --output-dir)",
+        "path_arg": true,
+        "type": "path"
+      },
       "--width": "",
       "--height": "",
       "--dpi": "",
@@ -211,23 +680,111 @@
   },
   "visualize animate": {
     "description": "datavizhub visualize animate",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--mode",
+          "--input",
+          "--inputs",
+          "--var",
+          "--uvar",
+          "--vvar",
+          "--u",
+          "--v",
+          "--output-dir",
+          "--manifest",
+          "--cmap",
+          "--levels",
+          "--vmin",
+          "--vmax",
+          "--basemap",
+          "--extent",
+          "--width",
+          "--height",
+          "--dpi",
+          "--density",
+          "--scale",
+          "--color",
+          "--colorbar",
+          "--label",
+          "--units",
+          "--show-timestamp",
+          "--timestamps-csv",
+          "--timestamp-loc",
+          "--features",
+          "--map-type",
+          "--tile-source",
+          "--tile-zoom",
+          "--xarray-engine",
+          "--no-coastline",
+          "--no-borders",
+          "--no-gridlines",
+          "--seed",
+          "--particles",
+          "--custom-seed",
+          "--dt",
+          "--steps-per-frame",
+          "--size",
+          "--method",
+          "--crs",
+          "--reproject",
+          "--to-video",
+          "--combine-to",
+          "--grid-cols",
+          "--grid-mode",
+          "--fps"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
       "--mode": "",
-      "--input": "Path to .nc 3D var or 3D .npy stack (for heatmap/contour/vector)",
-      "--inputs": "Multiple inputs for batch animations",
+      "--input": {
+        "help": "Path to .nc 3D var or 3D .npy stack (for heatmap/contour/vector)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--inputs": {
+        "help": "Multiple inputs for batch animations",
+        "path_arg": true,
+        "type": "path"
+      },
       "--var": "NetCDF variable name (heatmap/contour)",
       "--uvar": "NetCDF: U variable name (vector/particles mode)",
       "--vvar": "NetCDF: V variable name (vector/particles mode)",
-      "--u": "Path to U .npy stack (vector/particles mode)",
-      "--v": "Path to V .npy stack (vector/particles mode)",
-      "--output-dir": "Directory to write frames",
-      "--manifest": "Optional manifest output path (JSON)",
+      "--u": {
+        "help": "Path to U .npy stack (vector/particles mode)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--v": {
+        "help": "Path to V .npy stack (vector/particles mode)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output-dir": {
+        "help": "Directory to write frames",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--manifest": {
+        "help": "Optional manifest output path (JSON)",
+        "path_arg": true,
+        "type": "path"
+      },
       "--cmap": "",
       "--levels": "Contour levels: count or comma-separated",
       "--vmin": "",
       "--vmax": "",
-      "--basemap": "Path to background image",
+      "--basemap": {
+        "help": "Path to background image",
+        "path_arg": true,
+        "type": "path"
+      },
       "--extent": "west east south north",
       "--width": "",
       "--height": "",
@@ -267,23 +824,106 @@
   },
   "visualize compose-video": {
     "description": "datavizhub visualize compose-video",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--frames",
+          "--output",
+          "--basemap",
+          "--fps"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--frames": "Directory containing frame_*.png files",
-      "--output": "Output MP4 path",
-      "--basemap": "Optional background image to overlay under frames",
+      "--frames": {
+        "help": "Directory containing frame_*.png files",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--output": {
+        "help": "Output MP4 path",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--basemap": {
+        "help": "Optional background image to overlay under frames",
+        "path_arg": true,
+        "type": "path"
+      },
       "--fps": ""
     }
   },
   "visualize interactive": {
     "description": "datavizhub visualize interactive",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input",
+          "--var",
+          "--mode",
+          "--engine",
+          "--output",
+          "--extent",
+          "--cmap",
+          "--features",
+          "--no-coastline",
+          "--no-borders",
+          "--no-gridlines",
+          "--colorbar",
+          "--label",
+          "--units",
+          "--timestamp",
+          "--timestamp-loc",
+          "--tiles",
+          "--zoom",
+          "--attribution",
+          "--wms-url",
+          "--wms-layers",
+          "--wms-format",
+          "--wms-transparent",
+          "--layer-control",
+          "--width",
+          "--height",
+          "--crs",
+          "--reproject",
+          "--time-column",
+          "--period",
+          "--transition-ms",
+          "--uvar",
+          "--vvar",
+          "--u",
+          "--v",
+          "--density",
+          "--scale",
+          "--color",
+          "--streamlines"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Path to .npy/.nc/.csv input",
+      "--input": {
+        "help": "Path to .npy/.nc/.csv input",
+        "path_arg": true,
+        "type": "path"
+      },
       "--var": "NetCDF variable name (for .nc inputs)",
       "--mode": "",
       "--engine": "",
-      "--output": "Output HTML path",
+      "--output": {
+        "help": "Output HTML path",
+        "path_arg": true,
+        "type": "path"
+      },
       "--extent": "",
       "--cmap": "",
       "--features": "Heatmap/contour only: features (may be ignored depending on engine)",
@@ -312,8 +952,16 @@
       "--transition-ms": "TimeDimension transition time (ms)",
       "--uvar": "NetCDF: U variable name (vector mode)",
       "--vvar": "NetCDF: V variable name (vector mode)",
-      "--u": "Path to U .npy array (vector mode)",
-      "--v": "Path to V .npy array (vector mode)",
+      "--u": {
+        "help": "Path to U .npy array (vector mode)",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--v": {
+        "help": "Path to V .npy array (vector mode)",
+        "path_arg": true,
+        "type": "path"
+      },
       "--density": "Vector: arrow sampling density (0<d<=1)",
       "--scale": "Vector: arrow length scale in degrees",
       "--color": "Vector: arrow/line color",
@@ -322,16 +970,49 @@
   },
   "decimate local": {
     "description": "datavizhub decimate local",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Input path or '-' for stdin"
+      "--input": {
+        "help": "Input path or '-' for stdin",
+        "path_arg": true,
+        "type": "path"
+      }
     }
   },
   "decimate s3": {
     "description": "datavizhub decimate s3",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input",
+          "--url",
+          "--bucket",
+          "--key"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Input path or '-' for stdin",
+      "--input": {
+        "help": "Input path or '-' for stdin",
+        "path_arg": true,
+        "type": "path"
+      },
       "--url": "Full URL s3://bucket/key",
       "--bucket": "Bucket name",
       "--key": "Object key (when using --bucket)"
@@ -339,24 +1020,73 @@
   },
   "decimate ftp": {
     "description": "datavizhub decimate ftp",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Input path or '-' for stdin"
+      "--input": {
+        "help": "Input path or '-' for stdin",
+        "path_arg": true,
+        "type": "path"
+      }
     }
   },
   "decimate post": {
     "description": "datavizhub decimate post",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input",
+          "--content-type"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Input path or '-' for stdin",
+      "--input": {
+        "help": "Input path or '-' for stdin",
+        "path_arg": true,
+        "type": "path"
+      },
       "--content-type": "Content-Type header"
     }
   },
   "decimate vimeo": {
     "description": "datavizhub decimate vimeo",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input",
+          "--name",
+          "--description",
+          "--replace-uri"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--input": "Input path or '-' for stdin",
+      "--input": {
+        "help": "Input path or '-' for stdin",
+        "path_arg": true,
+        "type": "path"
+      },
       "--name": "Video title",
       "--description": "Video description",
       "--replace-uri": "Replace existing video at this Vimeo URI"
@@ -364,57 +1094,188 @@
   },
   "transform metadata": {
     "description": "datavizhub transform metadata",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--frames-dir",
+          "--pattern",
+          "--datetime-format",
+          "--period-seconds",
+          "--output"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--frames-dir": "Directory containing frames",
+      "--frames-dir": {
+        "help": "Directory containing frames",
+        "path_arg": true,
+        "type": "path"
+      },
       "--pattern": "Regex filter for frame filenames",
       "--datetime-format": "Datetime format used in filenames (e.g., %Y%m%d%H%M%S)",
       "--period-seconds": "Expected cadence to compute missing frames",
-      "--output": "Output path or '-' for stdout"
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path"
+      }
     }
   },
   "transform enrich-metadata": {
     "description": "datavizhub transform enrich-metadata",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--frames-meta",
+          "--dataset-id",
+          "--vimeo-uri",
+          "--read-vimeo-uri",
+          "--output"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
-      "--frames-meta": "Path to frames metadata JSON",
+      "--frames-meta": {
+        "help": "Path to frames metadata JSON",
+        "path_arg": true,
+        "type": "path"
+      },
       "--dataset-id": "Dataset identifier to embed",
       "--vimeo-uri": "Vimeo video URI to embed in metadata",
       "--read-vimeo-uri": "Read Vimeo URI from stdin (first line)",
-      "--output": "Output path or '-' for stdout"
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path"
+      }
     }
   },
   "transform update-dataset-json": {
     "description": "datavizhub transform update-dataset-json",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--input-url",
+          "--input-file",
+          "--dataset-id",
+          "--meta",
+          "--read-meta-stdin",
+          "--start",
+          "--end",
+          "--vimeo-uri",
+          "--no-set-data-link",
+          "--output"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
       "--input-url": "HTTP(S) or s3:// URL of dataset.json",
-      "--input-file": "Local dataset.json path",
+      "--input-file": {
+        "help": "Local dataset.json path",
+        "path_arg": true,
+        "type": "path"
+      },
       "--dataset-id": "Dataset id to update",
-      "--meta": "Path to metadata JSON containing start_datetime/end_datetime/vimeo_uri",
-      "--read-meta-stdin": "Read metadata JSON from stdin",
+      "--meta": {
+        "help": "Path to metadata JSON containing start_datetime/end_datetime/vimeo_uri",
+        "path_arg": true,
+        "type": "path"
+      },
+      "--read-meta-stdin": {
+        "help": "Read metadata JSON from stdin",
+        "type": "str",
+        "default": false
+      },
       "--start": "Explicit startTime override (ISO)",
       "--end": "Explicit endTime override (ISO)",
       "--vimeo-uri": "Explicit Vimeo URI (e.g., /videos/12345)",
-      "--no-set-data-link": "Do not update dataLink from Vimeo URI",
-      "--output": "Output path or '-' for stdout"
+      "--no-set-data-link": {
+        "help": "Do not update dataLink from Vimeo URI",
+        "type": "str",
+        "default": false
+      },
+      "--output": {
+        "help": "Output path or '-' for stdout",
+        "path_arg": true,
+        "type": "path"
+      }
     }
   },
   "run": {
     "description": "datavizhub run",
+    "doc": "",
+    "epilog": "",
+    "groups": [
+      {
+        "title": "options",
+        "options": [
+          "--help",
+          "--set",
+          "--print-argv",
+          "--print-argv-format",
+          "--dry-run",
+          "--continue-on-error",
+          "--start",
+          "--end",
+          "--only",
+          "--verbose",
+          "--quiet",
+          "--strict-env"
+        ]
+      }
+    ],
     "options": {
       "--help": "show this help message and exit",
       "--set": "Override key=value in args across stages",
-      "--print-argv": "Print argv per stage before running",
+      "--print-argv": {
+        "help": "Print argv per stage before running",
+        "type": "str",
+        "default": false
+      },
       "--print-argv-format": "",
-      "--dry-run": "Only print argv; do not execute stages",
-      "--continue-on-error": "Continue executing remaining stages even if one fails",
+      "--dry-run": {
+        "help": "Only print argv; do not execute stages",
+        "type": "str",
+        "default": false
+      },
+      "--continue-on-error": {
+        "help": "Continue executing remaining stages even if one fails",
+        "type": "str",
+        "default": false
+      },
       "--start": "1-based index of first stage to run",
       "--end": "1-based index of last stage to run",
       "--only": "Run only stages matching this alias (acquire/process/visualize/decimate)",
-      "--verbose": "Verbose runner output (prints stage headings)",
-      "--quiet": "Suppress runner messages when possible",
-      "--strict-env": "Fail if ${VAR} placeholders are not set in environment"
+      "--verbose": {
+        "help": "Verbose runner output (prints stage headings)",
+        "type": "str",
+        "default": false
+      },
+      "--quiet": {
+        "help": "Suppress runner messages when possible",
+        "type": "str",
+        "default": false
+      },
+      "--strict-env": {
+        "help": "Fail if ${VAR} placeholders are not set in environment",
+        "type": "str",
+        "default": false
+      }
     }
   }
 }

--- a/src/datavizhub/wizard/datavizhub_capabilities.json
+++ b/src/datavizhub/wizard/datavizhub_capabilities.json
@@ -1,0 +1,420 @@
+{
+  "acquire http": {
+    "description": "datavizhub acquire http",
+    "options": {
+      "--help": "show this help message and exit",
+      "--output": "Output path or '-' for stdout",
+      "--list": "List links on a directory page",
+      "--pattern": "Regex to filter listed links",
+      "--since": "ISO date filter for list mode",
+      "--since-period": "ISO-8601 duration for lookback (e.g., P1Y, P6M, P7D, PT24H)",
+      "--until": "ISO date filter for list mode",
+      "--date-format": "Filename date format for list filtering (e.g., YYYYMMDD)",
+      "--inputs": "Multiple HTTP URLs to fetch",
+      "--manifest": "Path to a file listing URLs (one per line)",
+      "--output-dir": "Directory to write outputs for --inputs"
+    }
+  },
+  "acquire s3": {
+    "description": "datavizhub acquire s3",
+    "options": {
+      "--help": "show this help message and exit",
+      "--url": "Full URL s3://bucket/key",
+      "--bucket": "Bucket name",
+      "--key": "Object key (when using --bucket)",
+      "--unsigned": "Use unsigned access for public buckets",
+      "--list": "List keys under a prefix",
+      "--pattern": "Regex to filter listed keys",
+      "--since": "ISO date filter for list mode",
+      "--since-period": "ISO-8601 duration for lookback (e.g., P1Y, P6M, P7D, PT24H)",
+      "--until": "ISO date filter for list mode",
+      "--date-format": "Filename date format for list filtering (e.g., YYYYMMDD)",
+      "--inputs": "Multiple s3:// URLs to fetch",
+      "--manifest": "Path to a file listing s3:// URLs (one per line)",
+      "--output-dir": "Directory to write outputs for --inputs",
+      "--output": "Output path or '-' for stdout"
+    }
+  },
+  "acquire ftp": {
+    "description": "datavizhub acquire ftp",
+    "options": {
+      "--help": "show this help message and exit",
+      "--output": "Output path or '-' for stdout",
+      "--list": "List files in an FTP directory",
+      "--sync-dir": "Sync FTP directory to a local directory",
+      "--pattern": "Regex to filter list/sync",
+      "--since": "ISO date filter for list/sync",
+      "--since-period": "ISO-8601 duration for lookback (e.g., P1Y, P6M, P7D, PT24H)",
+      "--until": "ISO date filter for list/sync",
+      "--date-format": "Filename date format for filtering (e.g., YYYYMMDD)",
+      "--inputs": "Multiple FTP paths to fetch",
+      "--manifest": "Path to a file listing FTP paths (one per line)",
+      "--output-dir": "Directory to write outputs for --inputs"
+    }
+  },
+  "acquire vimeo": {
+    "description": "datavizhub acquire vimeo",
+    "options": {
+      "--help": "show this help message and exit",
+      "--output": "Output path or '-' for stdout"
+    }
+  },
+  "process decode-grib2": {
+    "description": "datavizhub process decode-grib2",
+    "options": {
+      "--help": "show this help message and exit",
+      "--backend": "",
+      "--pattern": "Regex for .idx-based subsetting when using HTTP/S3",
+      "--unsigned": "Use unsigned S3 access for public buckets",
+      "--raw": "Emit raw (optionally .idx-subset) GRIB2 bytes to stdout"
+    }
+  },
+  "process extract-variable": {
+    "description": "datavizhub process extract-variable",
+    "options": {
+      "--help": "show this help message and exit",
+      "--backend": "",
+      "--stdout": "Write selected variable as bytes to stdout",
+      "--format": "Output format for --stdout"
+    }
+  },
+  "process convert-format": {
+    "description": "datavizhub process convert-format",
+    "options": {
+      "--help": "show this help message and exit",
+      "--output": "",
+      "--stdout": "Write binary output to stdout instead of a file",
+      "--inputs": "Multiple input paths or URLs",
+      "--output-dir": "Directory to write outputs for --inputs",
+      "--backend": "",
+      "--var": "Variable name or regex for multi-var datasets",
+      "--pattern": "Regex for .idx-based subsetting when using HTTP/S3",
+      "--unsigned": "Use unsigned S3 access for public buckets"
+    }
+  },
+  "visualize heatmap": {
+    "description": "datavizhub visualize heatmap",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Path to .nc or .npy input",
+      "--var": "Variable name for NetCDF inputs",
+      "--basemap": "Path to background image",
+      "--extent": "west east south north",
+      "--output": "Output PNG path (required when using --input; for --inputs use --output-dir)",
+      "--inputs": "Multiple input paths for batch rendering",
+      "--output-dir": "Directory to write outputs for --inputs",
+      "--width": "",
+      "--height": "",
+      "--dpi": "",
+      "--cmap": "",
+      "--colorbar": "",
+      "--label": "",
+      "--units": "",
+      "--features": "Comma-separated features: coastline,borders,gridlines",
+      "--xarray-engine": "xarray engine for NetCDF inputs (e.g., netcdf4, h5netcdf, scipy)",
+      "--map-type": "Basemap type: image (default) or tile",
+      "--tile-source": "Contextily tile source name or URL (when --map-type=tile)",
+      "--tile-zoom": "Tile source zoom level",
+      "--timestamp": "Overlay timestamp string",
+      "--crs": "Force input CRS (e.g., EPSG:3857)",
+      "--reproject": "Attempt reprojection to EPSG:4326 (limited support)",
+      "--timestamp-loc": "Timestamp placement (axes-relative)",
+      "--no-coastline": "",
+      "--no-borders": "",
+      "--no-gridlines": ""
+    }
+  },
+  "visualize contour": {
+    "description": "datavizhub visualize contour",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Path to .nc or .npy input",
+      "--inputs": "Multiple inputs for batch rendering",
+      "--output-dir": "Directory to write outputs for --inputs",
+      "--var": "Variable name for NetCDF inputs",
+      "--basemap": "Path to background image",
+      "--extent": "west east south north",
+      "--output": "Output PNG path (required for single --input; when using --inputs, prefer --output-dir)",
+      "--width": "",
+      "--height": "",
+      "--dpi": "",
+      "--cmap": "",
+      "--filled": "Use filled contours",
+      "--levels": "Count or comma-separated levels",
+      "--colorbar": "",
+      "--label": "",
+      "--units": "",
+      "--features": "Comma-separated features: coastline,borders,gridlines",
+      "--xarray-engine": "xarray engine for NetCDF inputs (e.g., netcdf4, h5netcdf, scipy)",
+      "--map-type": "",
+      "--tile-source": "Contextily tile source (when --map-type=tile)",
+      "--tile-zoom": "",
+      "--timestamp": "Overlay timestamp string",
+      "--crs": "Force input CRS (e.g., EPSG:3857)",
+      "--reproject": "",
+      "--timestamp-loc": "Timestamp placement (axes-relative)",
+      "--no-coastline": "",
+      "--no-borders": "",
+      "--no-gridlines": ""
+    }
+  },
+  "visualize timeseries": {
+    "description": "datavizhub visualize timeseries",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Path to .csv or .nc input",
+      "--x": "CSV: X column name (e.g., time)",
+      "--y": "CSV: Y column name (value)",
+      "--var": "NetCDF: variable name to plot",
+      "--output": "Output PNG path",
+      "--width": "",
+      "--height": "",
+      "--dpi": "",
+      "--title": "",
+      "--xlabel": "",
+      "--ylabel": "",
+      "--style": ""
+    }
+  },
+  "visualize vector": {
+    "description": "datavizhub visualize vector",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Path to .nc input (alternative to --u/--v .npy)",
+      "--inputs": "Multiple inputs for batch rendering",
+      "--output-dir": "Directory to write outputs for --inputs",
+      "--uvar": "NetCDF: U variable name",
+      "--vvar": "NetCDF: V variable name",
+      "--u": "Path to U .npy file (alternative input)",
+      "--v": "Path to V .npy file (alternative input)",
+      "--basemap": "Path to background image",
+      "--extent": "west east south north",
+      "--output": "Output PNG path (required for single --input/--u/--v; when using --inputs, prefer --output-dir)",
+      "--width": "",
+      "--height": "",
+      "--dpi": "",
+      "--density": "Arrow sampling density (0<d<=1)",
+      "--scale": "Quiver scale controlling arrow length",
+      "--color": "Arrow color",
+      "--features": "Comma-separated features: coastline,borders,gridlines",
+      "--xarray-engine": "xarray engine for NetCDF inputs (e.g., netcdf4, h5netcdf, scipy)",
+      "--map-type": "",
+      "--tile-source": "Contextily tile source (when --map-type=tile)",
+      "--tile-zoom": "",
+      "--streamlines": "Render streamlines instead of quiver",
+      "--crs": "Force input CRS (e.g., EPSG:3857)",
+      "--reproject": "",
+      "--no-coastline": "",
+      "--no-borders": "",
+      "--no-gridlines": ""
+    }
+  },
+  "visualize animate": {
+    "description": "datavizhub visualize animate",
+    "options": {
+      "--help": "show this help message and exit",
+      "--mode": "",
+      "--input": "Path to .nc 3D var or 3D .npy stack (for heatmap/contour/vector)",
+      "--inputs": "Multiple inputs for batch animations",
+      "--var": "NetCDF variable name (heatmap/contour)",
+      "--uvar": "NetCDF: U variable name (vector/particles mode)",
+      "--vvar": "NetCDF: V variable name (vector/particles mode)",
+      "--u": "Path to U .npy stack (vector/particles mode)",
+      "--v": "Path to V .npy stack (vector/particles mode)",
+      "--output-dir": "Directory to write frames",
+      "--manifest": "Optional manifest output path (JSON)",
+      "--cmap": "",
+      "--levels": "Contour levels: count or comma-separated",
+      "--vmin": "",
+      "--vmax": "",
+      "--basemap": "Path to background image",
+      "--extent": "west east south north",
+      "--width": "",
+      "--height": "",
+      "--dpi": "",
+      "--density": "Vector mode: arrow sampling density (0<d<=1)",
+      "--scale": "Vector mode: quiver scale controlling arrow length",
+      "--color": "Vector/particles color",
+      "--colorbar": "Heatmap/contour: draw colorbar",
+      "--label": "Heatmap/contour colorbar label",
+      "--units": "Heatmap/contour units for colorbar",
+      "--show-timestamp": "Overlay timestamps per frame if available",
+      "--timestamps-csv": "CSV with one timestamp per line (overrides auto)",
+      "--timestamp-loc": "Timestamp placement (axes-relative)",
+      "--features": "Heatmap/contour: comma-separated features",
+      "--map-type": "",
+      "--tile-source": "Contextily tile source (when --map-type=tile)",
+      "--tile-zoom": "",
+      "--xarray-engine": "xarray engine for NetCDF inputs (e.g., netcdf4, h5netcdf, scipy)",
+      "--no-coastline": "",
+      "--no-borders": "",
+      "--no-gridlines": "",
+      "--seed": "Particles: seeding strategy",
+      "--particles": "Particles: count for grid/random seeding",
+      "--custom-seed": "Particles: CSV with lon,lat columns",
+      "--dt": "Particles: integration step",
+      "--steps-per-frame": "Particles: substeps per frame",
+      "--size": "Particles: marker size",
+      "--method": "Particles: integrator",
+      "--crs": "Force input CRS for heatmap/contour/vector",
+      "--reproject": "",
+      "--to-video": "Optional: compose frames to MP4 using ffmpeg (single or per-input when using --inputs)",
+      "--combine-to": "Optional: compose per-input videos into a single MP4 grid",
+      "--grid-cols": "Grid columns for --combine-to (default 2)",
+      "--grid-mode": "Composition mode for --combine-to. 'grid' uses ffmpeg xstack (inputs must share the same width/height); if sizes differ, pre-scale inputs or use '--grid-mode hstack' to compose horizontally.",
+      "--fps": "Frames per second for video composition"
+    }
+  },
+  "visualize compose-video": {
+    "description": "datavizhub visualize compose-video",
+    "options": {
+      "--help": "show this help message and exit",
+      "--frames": "Directory containing frame_*.png files",
+      "--output": "Output MP4 path",
+      "--basemap": "Optional background image to overlay under frames",
+      "--fps": ""
+    }
+  },
+  "visualize interactive": {
+    "description": "datavizhub visualize interactive",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Path to .npy/.nc/.csv input",
+      "--var": "NetCDF variable name (for .nc inputs)",
+      "--mode": "",
+      "--engine": "",
+      "--output": "Output HTML path",
+      "--extent": "",
+      "--cmap": "",
+      "--features": "Heatmap/contour only: features (may be ignored depending on engine)",
+      "--no-coastline": "",
+      "--no-borders": "",
+      "--no-gridlines": "",
+      "--colorbar": "",
+      "--label": "",
+      "--units": "",
+      "--timestamp": "",
+      "--timestamp-loc": "",
+      "--tiles": "Folium: tile layer name/URL",
+      "--zoom": "Folium: initial zoom",
+      "--attribution": "Folium: attribution for custom tiles/WMS",
+      "--wms-url": "Folium: WMS base URL",
+      "--wms-layers": "Folium: WMS layer names",
+      "--wms-format": "",
+      "--wms-transparent": "",
+      "--layer-control": "Add a layer control switcher",
+      "--width": "Plotly: width",
+      "--height": "Plotly: height",
+      "--crs": "Force input CRS",
+      "--reproject": "",
+      "--time-column": "CSV points: column containing ISO8601 time strings",
+      "--period": "TimeDimension period (e.g., P1D)",
+      "--transition-ms": "TimeDimension transition time (ms)",
+      "--uvar": "NetCDF: U variable name (vector mode)",
+      "--vvar": "NetCDF: V variable name (vector mode)",
+      "--u": "Path to U .npy array (vector mode)",
+      "--v": "Path to V .npy array (vector mode)",
+      "--density": "Vector: arrow sampling density (0<d<=1)",
+      "--scale": "Vector: arrow length scale in degrees",
+      "--color": "Vector: arrow/line color",
+      "--streamlines": "Vector: render streamlines image overlay"
+    }
+  },
+  "decimate local": {
+    "description": "datavizhub decimate local",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Input path or '-' for stdin"
+    }
+  },
+  "decimate s3": {
+    "description": "datavizhub decimate s3",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Input path or '-' for stdin",
+      "--url": "Full URL s3://bucket/key",
+      "--bucket": "Bucket name",
+      "--key": "Object key (when using --bucket)"
+    }
+  },
+  "decimate ftp": {
+    "description": "datavizhub decimate ftp",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Input path or '-' for stdin"
+    }
+  },
+  "decimate post": {
+    "description": "datavizhub decimate post",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Input path or '-' for stdin",
+      "--content-type": "Content-Type header"
+    }
+  },
+  "decimate vimeo": {
+    "description": "datavizhub decimate vimeo",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input": "Input path or '-' for stdin",
+      "--name": "Video title",
+      "--description": "Video description",
+      "--replace-uri": "Replace existing video at this Vimeo URI"
+    }
+  },
+  "transform metadata": {
+    "description": "datavizhub transform metadata",
+    "options": {
+      "--help": "show this help message and exit",
+      "--frames-dir": "Directory containing frames",
+      "--pattern": "Regex filter for frame filenames",
+      "--datetime-format": "Datetime format used in filenames (e.g., %Y%m%d%H%M%S)",
+      "--period-seconds": "Expected cadence to compute missing frames",
+      "--output": "Output path or '-' for stdout"
+    }
+  },
+  "transform enrich-metadata": {
+    "description": "datavizhub transform enrich-metadata",
+    "options": {
+      "--help": "show this help message and exit",
+      "--frames-meta": "Path to frames metadata JSON",
+      "--dataset-id": "Dataset identifier to embed",
+      "--vimeo-uri": "Vimeo video URI to embed in metadata",
+      "--read-vimeo-uri": "Read Vimeo URI from stdin (first line)",
+      "--output": "Output path or '-' for stdout"
+    }
+  },
+  "transform update-dataset-json": {
+    "description": "datavizhub transform update-dataset-json",
+    "options": {
+      "--help": "show this help message and exit",
+      "--input-url": "HTTP(S) or s3:// URL of dataset.json",
+      "--input-file": "Local dataset.json path",
+      "--dataset-id": "Dataset id to update",
+      "--meta": "Path to metadata JSON containing start_datetime/end_datetime/vimeo_uri",
+      "--read-meta-stdin": "Read metadata JSON from stdin",
+      "--start": "Explicit startTime override (ISO)",
+      "--end": "Explicit endTime override (ISO)",
+      "--vimeo-uri": "Explicit Vimeo URI (e.g., /videos/12345)",
+      "--no-set-data-link": "Do not update dataLink from Vimeo URI",
+      "--output": "Output path or '-' for stdout"
+    }
+  },
+  "run": {
+    "description": "datavizhub run",
+    "options": {
+      "--help": "show this help message and exit",
+      "--set": "Override key=value in args across stages",
+      "--print-argv": "Print argv per stage before running",
+      "--print-argv-format": "",
+      "--dry-run": "Only print argv; do not execute stages",
+      "--continue-on-error": "Continue executing remaining stages even if one fails",
+      "--start": "1-based index of first stage to run",
+      "--end": "1-based index of last stage to run",
+      "--only": "Run only stages matching this alias (acquire/process/visualize/decimate)",
+      "--verbose": "Verbose runner output (prints stage headings)",
+      "--quiet": "Suppress runner messages when possible",
+      "--strict-env": "Fail if ${VAR} placeholders are not set in environment"
+    }
+  }
+}

--- a/src/datavizhub/wizard/llm_client.py
+++ b/src/datavizhub/wizard/llm_client.py
@@ -2,27 +2,32 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class LLMClient:
     name: str = "base"
-    model: Optional[str] = None
+    model: str | None = None
 
-    def generate(self, system_prompt: str, user_prompt: str) -> str:  # pragma: no cover - thin wrapper
+    def generate(
+        self, system_prompt: str, user_prompt: str
+    ) -> str:  # pragma: no cover - thin wrapper
         raise NotImplementedError
 
 
 class OpenAIClient(LLMClient):
     name = "openai"
 
-    def __init__(self, model: Optional[str] = None) -> None:
-        super().__init__(model=model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "gpt-4o-mini")
+    def __init__(self, model: str | None = None) -> None:
+        super().__init__(
+            model=model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "gpt-4o-mini"
+        )
         self.api_key = os.environ.get("OPENAI_API_KEY")
         self.base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
 
-    def generate(self, system_prompt: str, user_prompt: str) -> str:  # pragma: no cover - network optional
+    def generate(
+        self, system_prompt: str, user_prompt: str
+    ) -> str:  # pragma: no cover - network optional
         if not self.api_key:
             # Soft-fail with guidance
             return (
@@ -30,10 +35,15 @@ class OpenAIClient(LLMClient):
                 + MockClient().generate(system_prompt, user_prompt)
             )
         import json
+
         try:
             import requests
+
             url = f"{self.base_url}/chat/completions"
-            headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            }
             payload = {
                 "model": self.model,
                 "messages": [
@@ -42,28 +52,35 @@ class OpenAIClient(LLMClient):
                 ],
                 "temperature": 0.2,
             }
-            resp = requests.post(url, headers=headers, data=json.dumps(payload), timeout=60)
+            resp = requests.post(
+                url, headers=headers, data=json.dumps(payload), timeout=60
+            )
             resp.raise_for_status()
             data = resp.json()
             return data["choices"][0]["message"]["content"].strip()
         except Exception as exc:
-            return (
-                f"# OpenAI error: {exc}\n"
-                + MockClient().generate(system_prompt, user_prompt)
+            return f"# OpenAI error: {exc}\n" + MockClient().generate(
+                system_prompt, user_prompt
             )
 
 
 class OllamaClient(LLMClient):
     name = "ollama"
 
-    def __init__(self, model: Optional[str] = None) -> None:
-        super().__init__(model=model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "mistral")
+    def __init__(self, model: str | None = None) -> None:
+        super().__init__(
+            model=model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "mistral"
+        )
         self.base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
 
-    def generate(self, system_prompt: str, user_prompt: str) -> str:  # pragma: no cover - network optional
+    def generate(
+        self, system_prompt: str, user_prompt: str
+    ) -> str:  # pragma: no cover - network optional
         import json
+
         try:
             import requests
+
             url = f"{self.base_url}/api/chat"
             payload = {
                 "model": self.model,
@@ -78,9 +95,8 @@ class OllamaClient(LLMClient):
             data = resp.json()
             return data.get("message", {}).get("content", "").strip()
         except Exception as exc:
-            return (
-                f"# Ollama error: {exc}\n"
-                + MockClient().generate(system_prompt, user_prompt)
+            return f"# Ollama error: {exc}\n" + MockClient().generate(
+                system_prompt, user_prompt
             )
 
 

--- a/src/datavizhub/wizard/llm_client.py
+++ b/src/datavizhub/wizard/llm_client.py
@@ -19,9 +19,11 @@ class OpenAIClient(LLMClient):
     name = "openai"
 
     def __init__(self, model: str | None = None) -> None:
-        super().__init__(
-            model=model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "gpt-4o-mini"
+        resolved_model = (
+            model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "gpt-4o-mini"
         )
+        # Initialize dataclass fields explicitly
+        super().__init__(name=self.name, model=resolved_model)
         self.api_key = os.environ.get("OPENAI_API_KEY")
         self.base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
 
@@ -68,9 +70,9 @@ class OllamaClient(LLMClient):
     name = "ollama"
 
     def __init__(self, model: str | None = None) -> None:
-        super().__init__(
-            model=model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "mistral"
-        )
+        resolved_model = model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "mistral"
+        # Initialize dataclass fields explicitly
+        super().__init__(name=self.name, model=resolved_model)
         self.base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
 
     def generate(
@@ -104,7 +106,8 @@ class MockClient(LLMClient):
     name = "mock"
 
     def __init__(self) -> None:
-        super().__init__(model=None)
+        # Ensure dataclass field 'name' is initialized correctly
+        super().__init__(name=self.name, model=None)
 
     def generate(self, system_prompt: str, user_prompt: str) -> str:
         q = user_prompt.lower()

--- a/src/datavizhub/wizard/llm_client.py
+++ b/src/datavizhub/wizard/llm_client.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class LLMClient:
+    name: str = "base"
+    model: Optional[str] = None
+
+    def generate(self, system_prompt: str, user_prompt: str) -> str:  # pragma: no cover - thin wrapper
+        raise NotImplementedError
+
+
+class OpenAIClient(LLMClient):
+    name = "openai"
+
+    def __init__(self, model: Optional[str] = None) -> None:
+        super().__init__(model=model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "gpt-4o-mini")
+        self.api_key = os.environ.get("OPENAI_API_KEY")
+        self.base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+
+    def generate(self, system_prompt: str, user_prompt: str) -> str:  # pragma: no cover - network optional
+        if not self.api_key:
+            # Soft-fail with guidance
+            return (
+                "# Missing OPENAI_API_KEY. Falling back to mock suggestion.\n"
+                + MockClient().generate(system_prompt, user_prompt)
+            )
+        import json
+        try:
+            import requests
+            url = f"{self.base_url}/chat/completions"
+            headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+            payload = {
+                "model": self.model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                "temperature": 0.2,
+            }
+            resp = requests.post(url, headers=headers, data=json.dumps(payload), timeout=60)
+            resp.raise_for_status()
+            data = resp.json()
+            return data["choices"][0]["message"]["content"].strip()
+        except Exception as exc:
+            return (
+                f"# OpenAI error: {exc}\n"
+                + MockClient().generate(system_prompt, user_prompt)
+            )
+
+
+class OllamaClient(LLMClient):
+    name = "ollama"
+
+    def __init__(self, model: Optional[str] = None) -> None:
+        super().__init__(model=model or os.environ.get("DATAVIZHUB_LLM_MODEL") or "mistral")
+        self.base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+
+    def generate(self, system_prompt: str, user_prompt: str) -> str:  # pragma: no cover - network optional
+        import json
+        try:
+            import requests
+            url = f"{self.base_url}/api/chat"
+            payload = {
+                "model": self.model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                "stream": False,
+            }
+            resp = requests.post(url, data=json.dumps(payload), timeout=60)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("message", {}).get("content", "").strip()
+        except Exception as exc:
+            return (
+                f"# Ollama error: {exc}\n"
+                + MockClient().generate(system_prompt, user_prompt)
+            )
+
+
+class MockClient(LLMClient):
+    name = "mock"
+
+    def __init__(self) -> None:
+        super().__init__(model=None)
+
+    def generate(self, system_prompt: str, user_prompt: str) -> str:
+        q = user_prompt.lower()
+        # Very small heuristic to return plausible commands
+        if "subset" in q and ("hrrr" in q or "colorado" in q):
+            return (
+                """Here are suggested commands:
+```bash
+datavizhub acquire https://example.com/hrrr.grib2 --output tmp.grib2
+datavizhub process convert-format tmp.grib2 --format netcdf --output tmp.nc
+datavizhub visualize heatmap --input tmp.nc --var TMP --output co.png
+```
+"""
+            ).strip()
+        if "convert" in q and ("netcdf" in q or "geotiff" in q or "grib" in q):
+            return (
+                """Try this:
+```bash
+datavizhub process convert-format input.nc --format geotiff --output output.tif
+```
+"""
+            ).strip()
+        # Generic default
+        return (
+            """Suggested command:
+```bash
+datavizhub --help
+```
+"""
+        ).strip()

--- a/src/datavizhub/wizard/manifest.py
+++ b/src/datavizhub/wizard/manifest.py
@@ -142,7 +142,13 @@ def _collect_options(p: argparse.ArgumentParser) -> dict[str, object]:
                 if isinstance(default_val, str) and default_val == argparse.SUPPRESS:  # type: ignore[attr-defined]
                     default_val = None
                 # Emit object only if we have metadata beyond plain help (for backward compat)
-                if is_path or choices or required or type_str not in (None, "str") or default_val is not None:
+                if (
+                    is_path
+                    or choices
+                    or required
+                    or type_str not in (None, "str")
+                    or default_val is not None
+                ):
                     obj: dict[str, object] = {"help": help_text}
                     if is_path:
                         obj["path_arg"] = True

--- a/src/datavizhub/wizard/manifest.py
+++ b/src/datavizhub/wizard/manifest.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict, List
+
+
+def _safe_register_all(sub: argparse._SubParsersAction) -> None:
+    """Register all top-level groups, skipping modules that fail to import.
+
+    Matches the fallback branch in datavizhub.cli but wraps imports in try/except
+    to avoid hard-failing when optional extras (e.g., cartopy) are missing.
+    """
+    # acquire
+    try:
+        from datavizhub.connectors import ingest as _ingest_mod
+
+        p_acq = sub.add_parser("acquire", help="Acquire/ingest data from sources")
+        acq_sub = p_acq.add_subparsers(dest="acquire_cmd", required=True)
+        _ingest_mod.register_cli(acq_sub)
+    except Exception:  # pragma: no cover - optional extras might be missing
+        pass
+
+    # process
+    try:
+        from datavizhub import processing as _process_mod
+
+        p_proc = sub.add_parser(
+            "process", help="Processing commands (GRIB/NetCDF/GeoTIFF)"
+        )
+        proc_sub = p_proc.add_subparsers(dest="process_cmd", required=True)
+        _process_mod.register_cli(proc_sub)
+    except Exception:  # pragma: no cover
+        pass
+
+    # visualize
+    try:
+        from datavizhub import visualization as _visual_mod
+
+        p_viz = sub.add_parser(
+            "visualize", help="Visualization commands (static/interactive/animation)"
+        )
+        viz_sub = p_viz.add_subparsers(dest="visualize_cmd", required=True)
+        _visual_mod.register_cli(viz_sub)
+    except Exception:  # pragma: no cover - heavy deps may be missing
+        pass
+
+    # decimate
+    try:
+        from datavizhub.connectors import egress as _egress_mod
+
+        p_decimate = sub.add_parser(
+            "decimate", help="Write/egress data to destinations"
+        )
+        dec_sub = p_decimate.add_subparsers(dest="decimate_cmd", required=True)
+        _egress_mod.register_cli(dec_sub)
+    except Exception:  # pragma: no cover
+        pass
+
+    # transform
+    try:
+        import datavizhub.transform as _transform_mod
+
+        p_tr = sub.add_parser("transform", help="Transform helpers (metadata, etc.)")
+        tr_sub = p_tr.add_subparsers(dest="transform_cmd", required=True)
+        _transform_mod.register_cli(tr_sub)
+    except Exception:  # pragma: no cover
+        pass
+
+    # run
+    try:
+        from datavizhub.pipeline_runner import register_cli_run as _register_run
+
+        _register_run(sub)
+    except Exception:  # pragma: no cover
+        pass
+
+
+def _collect_options(p: argparse.ArgumentParser) -> Dict[str, str]:
+    opts: Dict[str, str] = {}
+    for act in getattr(p, "_actions", []):  # type: ignore[attr-defined]
+        if act.option_strings:
+            # choose the long option if available, else the first one
+            opt = None
+            for s in act.option_strings:
+                if s.startswith("--"):
+                    opt = s
+                    break
+            if opt is None and act.option_strings:
+                opt = act.option_strings[0]
+            if opt:
+                opts[opt] = (act.help or "").strip()
+    return opts
+
+
+def _traverse(parser: argparse.ArgumentParser, *, prefix: str = "") -> Dict[str, Any]:
+    """Recursively traverse subparsers to build a manifest mapping."""
+    manifest: Dict[str, Any] = {}
+    # find subparsers actions
+    sub_actions = [a for a in getattr(parser, "_actions", []) if a.__class__.__name__ == "_SubParsersAction"]  # type: ignore[attr-defined]
+    if not sub_actions:
+        # Leaf command: collect options and description
+        name = prefix.strip()
+        if name:  # skip root
+            manifest[name] = {
+                "description": (parser.description or parser.prog or "").strip(),
+                "options": _collect_options(parser),
+            }
+        return manifest
+
+    for spa in sub_actions:  # type: ignore[misc]
+        for name, subp in spa.choices.items():  # type: ignore[attr-defined]
+            # Skip wizard and manifest generator to avoid recursion/noise
+            if prefix == "" and name in {"wizard", "generate-manifest"}:
+                continue
+            manifest.update(_traverse(subp, prefix=f"{prefix} {name}"))
+    return manifest
+
+
+def build_manifest() -> Dict[str, Any]:
+    parser = argparse.ArgumentParser(prog="datavizhub")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    _safe_register_all(sub)
+    return _traverse(parser)
+
+
+def save_manifest(path: str) -> None:
+    data = build_manifest()
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+

--- a/tests/cli/test_manifest_smoke.py
+++ b/tests/cli/test_manifest_smoke.py
@@ -1,0 +1,20 @@
+def test_manifest_contains_core_groups():
+    """Smoke-test the capabilities manifest builder for core groups.
+
+    Narrow scope: Only asserts that at least one command path for each core
+    group exists. This avoids coupling to optional/extras or specific
+    subcommand names while still catching regressions.
+    """
+    from datavizhub.wizard.manifest import build_manifest
+
+    mf = build_manifest()
+    keys = list(mf.keys())
+
+    has_acquire = any(k.startswith("acquire ") for k in keys)
+    has_visualize = any(k.startswith("visualize ") for k in keys)
+
+    assert has_acquire and has_visualize, (
+        "manifest missing expected core commands: "
+        f"acquire={has_acquire}, visualize={has_visualize}"
+    )
+

--- a/tests/cli/test_manifest_smoke.py
+++ b/tests/cli/test_manifest_smoke.py
@@ -17,4 +17,3 @@ def test_manifest_contains_core_groups():
         "manifest missing expected core commands: "
         f"acquire={has_acquire}, visualize={has_visualize}"
     )
-

--- a/tests/cli/test_wizard_cli.py
+++ b/tests/cli/test_wizard_cli.py
@@ -1,6 +1,3 @@
-import os
-from pathlib import Path
-
 import pytest
 
 
@@ -19,14 +16,16 @@ def test_wizard_mock_prompt_dry_run_outputs_commands(capsys):
     """Mock provider with --dry-run should print suggested commands and return 0."""
     from datavizhub.cli import main
 
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "something",
-        "--dry-run",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "something",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     out = capsys.readouterr().out
     # The mock client always prints a 'datavizhub ...' suggestion
@@ -42,15 +41,17 @@ def test_wizard_logs_created(tmp_path, monkeypatch):
     fake_home.mkdir()
     monkeypatch.setenv("HOME", str(fake_home))
 
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "example",
-        "--dry-run",
-        "--log",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "example",
+            "--dry-run",
+            "--log",
+        ]
+    )
     assert rc == 0
 
     logs_dir = fake_home / ".datavizhub" / "wizard_logs"
@@ -78,14 +79,16 @@ $ datavizhub process convert-format input.nc --format geotiff --output out.tif
 
     monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
 
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "anything",
-        "--dry-run",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "anything",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     out = capsys.readouterr().out
     # Ensure the printed command has no leading "$ " and starts with datavizhub
@@ -115,14 +118,16 @@ datavizhub two
 
     monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
 
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "multi",
-        "--dry-run",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "multi",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     out = capsys.readouterr().out
     assert "datavizhub one" in out
@@ -145,14 +150,16 @@ datavizhub process convert-format input.nc --format geotiff --output out.tif # e
 
     monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
 
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "comments",
-        "--dry-run",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "comments",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     out = capsys.readouterr().out
     assert "# explain why" not in out
@@ -176,14 +183,16 @@ datavizhub ok
 
     monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
 
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "safe",
-        "--dry-run",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "safe",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     out = capsys.readouterr().out
     assert "datavizhub ok" in out
@@ -194,24 +203,24 @@ def test_wizard_show_raw_prints_reply(capsys, monkeypatch):
     from datavizhub.wizard import llm_client
 
     def fake_generate(system_prompt: str, user_prompt: str) -> str:
-        return (
-            """RAWXYZ
+        return """RAWXYZ
 ```
 datavizhub process convert-format input.nc geotiff --output out.tif
 ```"""
-        )
 
     monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
 
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "convert",
-        "--show-raw",
-        "--dry-run",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "convert",
+            "--show-raw",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     out = capsys.readouterr().out
     assert "Raw model output:" in out
@@ -230,31 +239,37 @@ datavizhub acquire input.grib2 -o output.nc  # convert GRIB2 to NetCDF
 """
     ).strip()
 
-    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(lambda s, u: reply))
+    monkeypatch.setattr(
+        llm_client.MockClient, "generate", staticmethod(lambda s, u: reply)
+    )
 
     # With --explain, the comment should appear in output
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "anything",
-        "--explain",
-        "--dry-run",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "anything",
+            "--explain",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     out_explain = capsys.readouterr().out
     assert "# convert GRIB2 to NetCDF" in out_explain
 
     # Without --explain, the printed suggestion should be stripped of comments
-    rc = main([
-        "wizard",
-        "--provider",
-        "mock",
-        "--prompt",
-        "anything",
-        "--dry-run",
-    ])
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "anything",
+            "--dry-run",
+        ]
+    )
     assert rc == 0
     out = capsys.readouterr().out
     assert "# convert GRIB2 to NetCDF" not in out

--- a/tests/cli/test_wizard_cli.py
+++ b/tests/cli/test_wizard_cli.py
@@ -1,0 +1,261 @@
+import os
+from pathlib import Path
+
+import pytest
+
+
+def test_wizard_help_works(capsys):
+    """Ensure `datavizhub wizard --help` shows usage and exits cleanly."""
+    from datavizhub.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["wizard", "--help"])  # argparse prints help then exits
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "usage: datavizhub wizard" in out
+
+
+def test_wizard_mock_prompt_dry_run_outputs_commands(capsys):
+    """Mock provider with --dry-run should print suggested commands and return 0."""
+    from datavizhub.cli import main
+
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "something",
+        "--dry-run",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The mock client always prints a 'datavizhub ...' suggestion
+    assert "datavizhub" in out
+
+
+def test_wizard_logs_created(tmp_path, monkeypatch):
+    """When --log is passed, a JSONL log file should be created under HOME."""
+    from datavizhub.cli import main
+
+    # Point HOME to a temp dir so we don't write to the real home directory
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "example",
+        "--dry-run",
+        "--log",
+    ])
+    assert rc == 0
+
+    logs_dir = fake_home / ".datavizhub" / "wizard_logs"
+    assert logs_dir.exists()
+    files = list(logs_dir.glob("*.jsonl"))
+    assert files, "Expected at least one JSONL log file to be created"
+    # Optional: ensure file is non-empty
+    assert any(f.stat().st_size > 0 for f in files)
+
+
+def test_wizard_extracts_bash_prompt_lines(capsys, monkeypatch):
+    """Commands with "$ datavizhub ..." in fenced code blocks are extracted and printed."""
+    from datavizhub.cli import main
+    from datavizhub.wizard import llm_client
+
+    def fake_generate(system_prompt: str, user_prompt: str) -> str:
+        return (
+            """
+Here you go:
+```bash
+$ datavizhub process convert-format input.nc --format geotiff --output out.tif
+```
+"""
+        ).strip()
+
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
+
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "anything",
+        "--dry-run",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Ensure the printed command has no leading "$ " and starts with datavizhub
+    assert "datavizhub process convert-format" in out
+    assert "$ datavizhub" not in out
+
+
+def test_wizard_extracts_multiple_fenced_blocks(capsys, monkeypatch):
+    """All fenced blocks are scanned; commands from each are listed."""
+    from datavizhub.cli import main
+    from datavizhub.wizard import llm_client
+
+    def fake_generate(system_prompt: str, user_prompt: str) -> str:
+        return (
+            """
+```bash
+$ datavizhub one
+```
+
+Some text
+
+```bash
+datavizhub two
+```
+"""
+        ).strip()
+
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
+
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "multi",
+        "--dry-run",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "datavizhub one" in out
+    assert "datavizhub two" in out
+
+
+def test_wizard_strips_inline_comments(capsys, monkeypatch):
+    """Inline comments after commands are removed from suggestions/output."""
+    from datavizhub.cli import main
+    from datavizhub.wizard import llm_client
+
+    def fake_generate(system_prompt: str, user_prompt: str) -> str:
+        return (
+            """
+```bash
+datavizhub process convert-format input.nc --format geotiff --output out.tif # explain why
+```
+"""
+        ).strip()
+
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
+
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "comments",
+        "--dry-run",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "# explain why" not in out
+    assert "datavizhub process convert-format" in out
+
+
+def test_wizard_safety_drops_unsafe_lines(capsys, monkeypatch):
+    """Non-datavizhub lines (e.g., rm -rf) are ignored with a notice."""
+    from datavizhub.cli import main
+    from datavizhub.wizard import llm_client
+
+    def fake_generate(system_prompt: str, user_prompt: str) -> str:
+        return (
+            """
+```bash
+rm -rf /
+datavizhub ok
+```
+"""
+        ).strip()
+
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
+
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "safe",
+        "--dry-run",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "datavizhub ok" in out
+
+
+def test_wizard_show_raw_prints_reply(capsys, monkeypatch):
+    from datavizhub.cli import main
+    from datavizhub.wizard import llm_client
+
+    def fake_generate(system_prompt: str, user_prompt: str) -> str:
+        return (
+            """RAWXYZ
+```
+datavizhub process convert-format input.nc geotiff --output out.tif
+```"""
+        )
+
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
+
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "convert",
+        "--show-raw",
+        "--dry-run",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Raw model output:" in out
+    assert "RAWXYZ" in out
+
+
+def test_wizard_explain_preserves_comments_but_default_strips(capsys, monkeypatch):
+    from datavizhub.cli import main
+    from datavizhub.wizard import llm_client
+
+    reply = (
+        """
+```bash
+datavizhub acquire input.grib2 -o output.nc  # convert GRIB2 to NetCDF
+```
+"""
+    ).strip()
+
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(lambda s, u: reply))
+
+    # With --explain, the comment should appear in output
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "anything",
+        "--explain",
+        "--dry-run",
+    ])
+    assert rc == 0
+    out_explain = capsys.readouterr().out
+    assert "# convert GRIB2 to NetCDF" in out_explain
+
+    # Without --explain, the printed suggestion should be stripped of comments
+    rc = main([
+        "wizard",
+        "--provider",
+        "mock",
+        "--prompt",
+        "anything",
+        "--dry-run",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "# convert GRIB2 to NetCDF" not in out
+    assert "rm -rf /" not in out

--- a/tests/cli/test_wizard_cli_config.py
+++ b/tests/cli/test_wizard_cli_config.py
@@ -1,0 +1,74 @@
+import textwrap
+
+
+def _monkeypatch_generators(monkeypatch):
+    from datavizhub.wizard import llm_client
+
+    def gen_openai(system_prompt: str, user_prompt: str) -> str:
+        return """
+```bash
+$ datavizhub from-openai
+```
+""".strip()
+
+    def gen_mock(system_prompt: str, user_prompt: str) -> str:
+        return """
+```bash
+$ datavizhub from-mock
+```
+""".strip()
+
+    monkeypatch.setattr(llm_client.OpenAIClient, "generate", staticmethod(gen_openai))
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(gen_mock))
+
+
+def test_config_file_sets_default_provider(tmp_path, monkeypatch, capsys):
+    from datavizhub.cli import main
+
+    # Point HOME to temp and write config with provider: mock
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    cfg = home / ".datavizhub_wizard.yaml"
+    cfg.write_text("provider: mock\n", encoding="utf-8")
+
+    _monkeypatch_generators(monkeypatch)
+
+    rc = main(["wizard", "--prompt", "hello", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "from-mock" in out
+    assert "from-openai" not in out
+
+
+def test_env_overrides_config(tmp_path, monkeypatch, capsys):
+    from datavizhub.cli import main
+
+    # Config says openai, env overrides to mock
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    (home / ".datavizhub_wizard.yaml").write_text("provider: openai\n", encoding="utf-8")
+    monkeypatch.setenv("DATAVIZHUB_LLM_PROVIDER", "mock")
+
+    _monkeypatch_generators(monkeypatch)
+
+    rc = main(["wizard", "--prompt", "hello", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "from-mock" in out
+    assert "from-openai" not in out
+
+
+def test_cli_overrides_env(monkeypatch, capsys):
+    from datavizhub.cli import main
+
+    monkeypatch.setenv("DATAVIZHUB_LLM_PROVIDER", "openai")
+    _monkeypatch_generators(monkeypatch)
+
+    rc = main(["wizard", "--provider", "mock", "--prompt", "hello", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "from-mock" in out
+    assert "from-openai" not in out
+

--- a/tests/cli/test_wizard_cli_config.py
+++ b/tests/cli/test_wizard_cli_config.py
@@ -1,6 +1,3 @@
-
-
-
 def _monkeypatch_generators(monkeypatch):
     from datavizhub.wizard import llm_client
 

--- a/tests/cli/test_wizard_cli_config.py
+++ b/tests/cli/test_wizard_cli_config.py
@@ -1,4 +1,4 @@
-import textwrap
+
 
 
 def _monkeypatch_generators(monkeypatch):
@@ -48,7 +48,9 @@ def test_env_overrides_config(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
-    (home / ".datavizhub_wizard.yaml").write_text("provider: openai\n", encoding="utf-8")
+    (home / ".datavizhub_wizard.yaml").write_text(
+        "provider: openai\n", encoding="utf-8"
+    )
     monkeypatch.setenv("DATAVIZHUB_LLM_PROVIDER", "mock")
 
     _monkeypatch_generators(monkeypatch)
@@ -71,4 +73,3 @@ def test_cli_overrides_env(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "from-mock" in out
     assert "from-openai" not in out
-

--- a/tests/cli/test_wizard_context_enrichment.py
+++ b/tests/cli/test_wizard_context_enrichment.py
@@ -1,0 +1,43 @@
+def test_context_includes_enriched_option_details(monkeypatch, capsys):
+    import datavizhub.wizard as wiz
+
+    # Override manifest loader to a tiny enriched manifest
+    cap = {
+        "visualize heatmap": {
+            "description": "Render a heatmap",
+            "doc": "Docstring here",
+            "epilog": "Epilog text",
+            "options": {
+                "--cmap": {"help": "Colormap", "choices": ["viridis", "plasma"], "default": "viridis"},
+                "--input": {"help": "Path", "path_arg": True},
+            },
+        }
+    }
+    monkeypatch.setattr(wiz, "_load_capabilities_manifest", lambda: cap)
+
+    seen = {}
+
+    def fake_generate(system_prompt: str, user_prompt: str) -> str:
+        seen["user_prompt"] = user_prompt
+        return "```bash\ndatavizhub --help\n```"
+
+    from datavizhub.wizard import llm_client
+
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(fake_generate))
+
+    rc = wiz._handle_prompt(
+        "heatmap with cmap",
+        provider="mock",
+        model=None,
+        dry_run=True,
+        assume_yes=True,
+        max_commands=None,
+        logfile=None,
+        session=wiz.SessionState(),
+    )
+    assert rc == 0
+    up = seen["user_prompt"]
+    # Should contain choices and default info in the context block
+    assert "choices: viridis, plasma" in up
+    assert "default: viridis" in up
+

--- a/tests/cli/test_wizard_context_enrichment.py
+++ b/tests/cli/test_wizard_context_enrichment.py
@@ -8,7 +8,11 @@ def test_context_includes_enriched_option_details(monkeypatch, capsys):
             "doc": "Docstring here",
             "epilog": "Epilog text",
             "options": {
-                "--cmap": {"help": "Colormap", "choices": ["viridis", "plasma"], "default": "viridis"},
+                "--cmap": {
+                    "help": "Colormap",
+                    "choices": ["viridis", "plasma"],
+                    "default": "viridis",
+                },
                 "--input": {"help": "Path", "path_arg": True},
             },
         }
@@ -40,4 +44,3 @@ def test_context_includes_enriched_option_details(monkeypatch, capsys):
     # Should contain choices and default info in the context block
     assert "choices: viridis, plasma" in up
     assert "default: viridis" in up
-

--- a/tests/cli/test_wizard_edit_flow.py
+++ b/tests/cli/test_wizard_edit_flow.py
@@ -1,0 +1,61 @@
+"""Tests for Wizard edit flow and manifest tokenization."""
+
+
+def test_wizard_edit_flow_sanitizes_and_runs(monkeypatch, capsys):
+    import datavizhub.wizard as wiz
+    from datavizhub.cli import main
+    from datavizhub.wizard import llm_client
+
+    # Force no prompt_toolkit and no external editor
+    monkeypatch.setattr(wiz, "PTK_AVAILABLE", False, raising=False)
+    monkeypatch.delenv("VISUAL", raising=False)
+    monkeypatch.delenv("EDITOR", raising=False)
+
+    # Mock LLM to suggest a simple command
+    monkeypatch.setattr(
+        llm_client.MockClient,
+        "generate",
+        staticmethod(lambda s, u: "```bash\ndatavizhub --help\n````"),
+    )
+
+    # Simulate user editing: provide an unsafe line and a commented command
+    inputs = iter(
+        [
+            "rm -rf /",  # unsafe - should be dropped
+            "datavizhub visualize heatmap --input in.nc --output out.png # note",  # safe
+            "",  # end of edit
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+
+    executed = []
+
+    def fake_run_one(cmd: str) -> int:
+        executed.append(cmd)
+        return 0
+
+    monkeypatch.setattr(wiz, "_run_one", fake_run_one)
+
+    # Ensure we pick edit mode
+    monkeypatch.setenv("DATAVIZHUB_WIZARD_EDITOR_MODE", "always")
+
+    rc = main(["wizard", "--provider", "mock", "--prompt", "x"])
+    assert rc == 0
+
+    # Only the sanitized datavizhub line should run (no inline comment)
+    assert executed == ["datavizhub visualize heatmap --input in.nc --output out.png"]
+
+
+def test_tokenize_manifest_basic():
+    import datavizhub.wizard as wiz
+
+    cap = wiz._load_capabilities_manifest()
+    assert cap is not None
+    toks = wiz._tokenize_manifest(cap)
+    # Expect some broad tokens
+    assert "acquire" in toks["first_tokens"]
+    assert isinstance(toks["options"], set)
+    # Common option presence
+    assert any(o.startswith("--output") for o in toks["options"]) or any(
+        o == "-o" for o in toks["options"]
+    )

--- a/tests/cli/test_wizard_group_display.py
+++ b/tests/cli/test_wizard_group_display.py
@@ -9,7 +9,11 @@ def test_group_title_in_option_completion_meta(monkeypatch):
             ],
             "options": {
                 "--input": {"help": "Path to input", "path_arg": True},
-                "--output": {"help": "Path to output", "path_arg": True, "default": "out.png"},
+                "--output": {
+                    "help": "Path to output",
+                    "path_arg": True,
+                    "default": "out.png",
+                },
             },
         }
     }

--- a/tests/cli/test_wizard_group_display.py
+++ b/tests/cli/test_wizard_group_display.py
@@ -1,0 +1,32 @@
+def test_group_title_in_option_completion_meta(monkeypatch):
+    # Build a small manifest with groups metadata
+    cap = {
+        "visualize heatmap": {
+            "description": "",
+            "groups": [
+                {"title": "Input Options", "options": ["--input"]},
+                {"title": "Output Options", "options": ["--output"]},
+            ],
+            "options": {
+                "--input": {"help": "Path to input", "path_arg": True},
+                "--output": {"help": "Path to output", "path_arg": True, "default": "out.png"},
+            },
+        }
+    }
+    import datavizhub.wizard as wiz
+
+    comp = wiz._WizardCompleter(cap)
+
+    class Doc:
+        text_before_cursor = "visualize heatmap --o"
+
+        @staticmethod
+        def get_word_before_cursor(WORD=False):
+            return "--o"
+
+    # Collect completions
+    got = list(comp.get_completions(Doc, None))  # type: ignore[arg-type]
+    # Ensure meta includes the group title and default
+    metas = {c.text: str(c.display_meta) for c in got}
+    assert "(Output Options)" in (metas.get("--output") or "")
+    assert "default: out.png" in (metas.get("--output") or "")

--- a/tests/cli/test_wizard_logging.py
+++ b/tests/cli/test_wizard_logging.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+
+def test_log_schema_and_correlation_fields(tmp_path, monkeypatch):
+    from datavizhub.cli import main
+
+    # Use a temp HOME so logs go to a known place
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    # Run wizard in dry-run with logging enabled to produce JSONL events
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "example",
+            "--dry-run",
+            "--log",
+        ]
+    )
+    assert rc == 0
+
+    logs_dir = home / ".datavizhub" / "wizard_logs"
+    files = sorted(logs_dir.glob("*.jsonl"))
+    assert files, "Expected a JSONL log file to be created"
+    log_path = files[-1]
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) >= 1
+
+    events = [json.loads(l) for l in lines]
+
+    # schema_version always present and equals 1
+    assert all(ev.get("schema_version") == 1 for ev in events)
+
+    # session_id stable across events in a single run
+    session_ids = {ev.get("session_id") for ev in events}
+    assert len(session_ids) == 1
+    assert next(iter(session_ids)), "session_id should be non-empty"
+
+    # event_id unique per event
+    event_ids = [ev.get("event_id") for ev in events]
+    assert all(bool(eid) for eid in event_ids), "event_id should be present"
+    assert len(set(event_ids)) == len(event_ids)
+
+
+def test_log_includes_assistant_reply_when_enabled(tmp_path, monkeypatch):
+    from datavizhub.cli import main
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    rc = main(
+        [
+            "wizard",
+            "--provider",
+            "mock",
+            "--prompt",
+            "example",
+            "--dry-run",
+            "--log",
+            "--log-raw-llm",
+        ]
+    )
+    assert rc == 0
+
+    logs_dir = home / ".datavizhub" / "wizard_logs"
+    files = sorted(logs_dir.glob("*.jsonl"))
+    assert files, "Expected a JSONL log file"
+    lines = files[-1].read_text(encoding="utf-8").strip().splitlines()
+    events = [json.loads(l) for l in lines]
+
+    replies = [ev for ev in events if ev.get("type") == "assistant_reply"]
+    assert replies, "Expected at least one assistant_reply event when --log-raw-llm is set"
+    assert any("raw" in ev and ev["raw"] for ev in replies)

--- a/tests/cli/test_wizard_logging.py
+++ b/tests/cli/test_wizard_logging.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 
 def test_log_schema_and_correlation_fields(tmp_path, monkeypatch):
@@ -31,7 +30,7 @@ def test_log_schema_and_correlation_fields(tmp_path, monkeypatch):
     lines = log_path.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) >= 1
 
-    events = [json.loads(l) for l in lines]
+    events = [json.loads(line) for line in lines]
 
     # schema_version always present and equals 1
     assert all(ev.get("schema_version") == 1 for ev in events)
@@ -72,8 +71,10 @@ def test_log_includes_assistant_reply_when_enabled(tmp_path, monkeypatch):
     files = sorted(logs_dir.glob("*.jsonl"))
     assert files, "Expected a JSONL log file"
     lines = files[-1].read_text(encoding="utf-8").strip().splitlines()
-    events = [json.loads(l) for l in lines]
+    events = [json.loads(line) for line in lines]
 
     replies = [ev for ev in events if ev.get("type") == "assistant_reply"]
-    assert replies, "Expected at least one assistant_reply event when --log-raw-llm is set"
+    assert (
+        replies
+    ), "Expected at least one assistant_reply event when --log-raw-llm is set"
     assert any("raw" in ev and ev["raw"] for ev in replies)

--- a/tests/cli/test_wizard_manifest_defaults.py
+++ b/tests/cli/test_wizard_manifest_defaults.py
@@ -1,0 +1,17 @@
+def test_tokenizer_captures_default_and_help():
+    import datavizhub.wizard as wiz
+
+    cap = {
+        "process convert-format": {
+            "description": "",
+            "options": {
+                "--format": {"help": "Output format", "choices": ["netcdf", "geotiff"], "default": "netcdf"},
+                "--output": {"help": "Output file", "path_arg": True},
+            },
+        }
+    }
+    toks = wiz._tokenize_manifest(cap)
+    meta = toks["opt_meta"].get(("process", "convert-format"), {})
+    assert meta.get("--format", {}).get("default") == "netcdf"
+    assert "help" in meta.get("--format", {})
+

--- a/tests/cli/test_wizard_session.py
+++ b/tests/cli/test_wizard_session.py
@@ -27,7 +27,8 @@ datavizhub visualize heatmap --input out1.nc --var TMP --output plot.png
 """
         ).strip()
 
-    # First call uses mock client, second also. Swap implementation dynamically by inspecting calls count
+    # Both calls use MockClient; select generator via len(calls):
+    # use gen_first when len(calls) == 0, else gen_second.
     def generate(system_prompt: str, user_prompt: str) -> str:
         return (
             gen_first(system_prompt, user_prompt)

--- a/tests/cli/test_wizard_session.py
+++ b/tests/cli/test_wizard_session.py
@@ -1,0 +1,63 @@
+from datavizhub.wizard import _handle_prompt, SessionState
+
+
+def test_session_memory_in_context(monkeypatch, capsys):
+    from datavizhub.wizard import llm_client
+
+    calls = []
+
+    def gen_first(system_prompt: str, user_prompt: str) -> str:
+        calls.append(user_prompt)
+        return (
+            """
+```bash
+datavizhub process convert-format input.nc netcdf --output out1.nc
+```
+"""
+        ).strip()
+
+    def gen_second(system_prompt: str, user_prompt: str) -> str:
+        calls.append(user_prompt)
+        assert "Last file: out1.nc" in user_prompt
+        return (
+            """
+```bash
+datavizhub visualize heatmap --input out1.nc --var TMP --output plot.png
+```
+"""
+        ).strip()
+
+    # First call uses mock client, second also. Swap implementation dynamically by inspecting calls count
+    def generate(system_prompt: str, user_prompt: str) -> str:
+        return gen_first(system_prompt, user_prompt) if len(calls) == 0 else gen_second(system_prompt, user_prompt)
+
+    monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(generate))
+
+    sess = SessionState()
+    # First prompt: execute (not dry-run) and auto-confirm to update session state
+    rc1 = _handle_prompt(
+        "subset HRRR",
+        provider="mock",
+        model=None,
+        dry_run=True,
+        assume_yes=True,
+        max_commands=None,
+        logfile=None,
+        session=sess,
+    )
+    assert rc1 == 0
+    assert sess.last_file == "out1.nc"
+    # Second prompt should include session context in user prompt and produce commands using last file
+    rc2 = _handle_prompt(
+        "make a heatmap",
+        provider="mock",
+        model=None,
+        dry_run=True,
+        assume_yes=True,
+        max_commands=None,
+        logfile=None,
+        session=sess,
+    )
+    assert rc2 == 0
+    out = capsys.readouterr().out
+    assert "datavizhub visualize heatmap --input out1.nc" in out

--- a/tests/cli/test_wizard_session.py
+++ b/tests/cli/test_wizard_session.py
@@ -1,4 +1,4 @@
-from datavizhub.wizard import _handle_prompt, SessionState
+from datavizhub.wizard import SessionState, _handle_prompt
 
 
 def test_session_memory_in_context(monkeypatch, capsys):
@@ -29,7 +29,11 @@ datavizhub visualize heatmap --input out1.nc --var TMP --output plot.png
 
     # First call uses mock client, second also. Swap implementation dynamically by inspecting calls count
     def generate(system_prompt: str, user_prompt: str) -> str:
-        return gen_first(system_prompt, user_prompt) if len(calls) == 0 else gen_second(system_prompt, user_prompt)
+        return (
+            gen_first(system_prompt, user_prompt)
+            if len(calls) == 0
+            else gen_second(system_prompt, user_prompt)
+        )
 
     monkeypatch.setattr(llm_client.MockClient, "generate", staticmethod(generate))
 

--- a/tests/cli/test_wizard_tokenizer_choices.py
+++ b/tests/cli/test_wizard_tokenizer_choices.py
@@ -1,0 +1,24 @@
+def test_tokenizer_extracts_choices_for_options():
+    import datavizhub.wizard as wiz
+
+    cap = {
+        "visualize heatmap": {
+            "description": "",
+            "options": {
+                "--cmap": {"help": "", "choices": ["viridis", "plasma", "magma"]},
+                "--output": {"help": "", "path_arg": True},
+            },
+        }
+    }
+    toks = wiz._tokenize_manifest(cap)
+    # Expect choices mapped for the specific command
+    oc = toks["opt_choices"]
+    assert ("visualize" in toks["first_tokens"]) and ("heatmap" in toks["commands"]) is False
+    # opt_choices uses keys (first, second)
+    choices = set()
+    for key, mapping in oc.items():
+        if key == ("visualize", "heatmap"):
+            choices = mapping.get("--cmap", set())
+            break
+    assert choices == {"viridis", "plasma", "magma"}
+

--- a/tests/cli/test_wizard_tokenizer_choices.py
+++ b/tests/cli/test_wizard_tokenizer_choices.py
@@ -13,7 +13,9 @@ def test_tokenizer_extracts_choices_for_options():
     toks = wiz._tokenize_manifest(cap)
     # Expect choices mapped for the specific command
     oc = toks["opt_choices"]
-    assert ("visualize" in toks["first_tokens"]) and ("heatmap" in toks["commands"]) is False
+    assert ("visualize" in toks["first_tokens"]) and (
+        "heatmap" in toks["commands"]
+    ) is False
     # opt_choices uses keys (first, second)
     choices = set()
     for key, mapping in oc.items():
@@ -21,4 +23,3 @@ def test_tokenizer_extracts_choices_for_options():
             choices = mapping.get("--cmap", set())
             break
     assert choices == {"viridis", "plasma", "magma"}
-


### PR DESCRIPTION
This pull request introduces an experimental "Wizard" REPL feature to DataVizHub, providing an interactive assistant for CLI command suggestions, autocomplete, and edit-before-run workflows. It also adds a capabilities manifest generator for CLI commands, refactors linting instructions to use Ruff, and updates dependencies and documentation to support the new wizard functionality.

**Wizard REPL and Manifest Generator:**

* Added a new `wizard` CLI command, with support for autocomplete and edit-before-run, leveraging `prompt_toolkit` if installed. Documentation for usage and editor behavior is provided in `docs/wizard-cli.md`. [[1]](diffhunk://#diff-457270e5c50eea0f9c2aeca0c36a69ad08b6d6ed2c0b9d888cfa40ab8980e9f5R1-R21) [[2]](diffhunk://#diff-956334314c05e2f472434751e81409664e34099289aabfb806e7a89e5e339cd1R528-R566) [[3]](diffhunk://#diff-956334314c05e2f472434751e81409664e34099289aabfb806e7a89e5e339cd1R594-R619)
* Implemented a capabilities manifest generator (`generate-manifest` CLI command) to output a JSON manifest of CLI commands and options, with robust handling for optional dependencies. [[1]](diffhunk://#diff-36d0052dde394073870c35d290f33eb4a3577f43e18999f0705cd8a31a00bd09R1-R227) [[2]](diffhunk://#diff-956334314c05e2f472434751e81409664e34099289aabfb806e7a89e5e339cd1R528-R566) [[3]](diffhunk://#diff-956334314c05e2f472434751e81409664e34099289aabfb806e7a89e5e339cd1R594-R619)

**Wizard REPL Backend and Testing:**

* Added LLM client backends (`OpenAIClient`, `OllamaClient`, `MockClient`) for command suggestion in the wizard, supporting both real and mock responses.
* Added a smoke test for manifest generation to ensure core command groups are present.

**Dependency and Packaging Updates:**

* Added `prompt_toolkit` as an optional dependency for the wizard, updated `pyproject.toml` to include wizard-related extras, and ensured wizard assets are included in packaging. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R8) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R33) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R110-R114) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R156-R157)

**Documentation and Linting:**

* Updated lint/format instructions to use Ruff instead of Black/Isort/Flake8, reflecting the new configuration.
* Added reference to the Wizard REPL in the main `README.md`.